### PR TITLE
Error: Uncaught TypeError: eventArray.findIndex is not a function: 747

### DIFF
--- a/src/js/tracking.js
+++ b/src/js/tracking.js
@@ -15,12 +15,14 @@ let tracking = {
 			});
 	},
 	findSynthEventIndex: function(eventArray, eventArguments){
-		var index = eventArray.findIndex(x => x.hasOwnProperty('_dispatchListeners'));
-		if (index === -1) {
-			return 'unknown';
-		}
-		else {
-			return this.returnFunctionName(index,eventArguments);
+
+		for (var i = 0; i < eventArray.length; i++) {
+			if (eventArray[i].hasOwnProperty('_dispatchListeners')) {
+				return this.returnFunctionName(i, eventArguments)
+			}
+			else{
+				return "Unknown"			
+			}
 		}
 	},
 	sliceArgumentArray: function(eventArguments){


### PR DESCRIPTION
Error: Uncaught TypeError: eventArray.findIndex is not a function: 747

"findIndex" method for arrays only supported through ES6
Rewrote FindIndex with for Loop that return index
Tested on FireFox version 20 and functional.

PULL REQUEST: https://github.com/neon-lab/wonderland/pull/22
JIRA: https://neonlabs.atlassian.net/browse/NEON-747
