### PR TITLE
ShortId no likey _ underscores + extra security / uniqueness for our Ids #785

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "browserify": "11.2.0",
     "bulma": "0.0.16",
     "connect-history-api-fallback": "1.1.0",
+    "fnv-plus": "^1.2.12",
     "gulp": "3.9.0",
     "gulp-notify": "2.2.0",
     "gulp-sass": "^2.2.0",

--- a/src/js/components/lookingglass/UploadForm.js
+++ b/src/js/components/lookingglass/UploadForm.js
@@ -2,7 +2,6 @@
 
 import React from 'react';
 import AJAX from '../../ajax';
-import shortid from 'shortid';
 import UTILS from '../../utils';
 import TRACKING from '../../tracking';
 
@@ -90,7 +89,7 @@ var UploadForm = React.createClass({
                     mode: 'loading'
                 });
                 var apiUrl = 'http://services.neon-lab.com/api/v2/' + AJAX.ACCOUNT_ID + '/videos',
-                    videoId = shortid.generate(),
+                    videoId = UTILS.generateId(),
                     options = {
                         method: 'POST',
                         body: JSON.stringify({

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,5 +1,12 @@
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
+var shortid = require('shortid'),
+    fnv = require('fnv-plus')
+;
+shortid.characters('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-~')
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
 var UNKNOWN_STRING = '?',
     UNKNOWN_EMOJI = '',
     NEONSCORES = [
@@ -116,6 +123,12 @@ let utils =  {
     },
     rando: function(num) {
         return Math.floor(Math.random() * num + 1);
+    },
+    generateId: function() {
+        var id = shortid.generate(),
+            hash64 = fnv.hash(id + Date.now(), 128)
+        ;
+        return hash64.str();
     },
     dropboxUrlFilter: function(s) {
         var returnValue = s;


### PR DESCRIPTION
- added new dependency, fan-plus
- moved generateId into utils
- changed the characters to not have underscores (problematic for us)
  and used hyphen and tilde
- generateId now (at Kevin’s suggestion) gets a shortId and hashes it
  with the current Unix timestamp appended (128 bits)
