### PR TITLE
Video component - no need to double check status #883

### DIFF
--- a/src/js/components/wonderland/Video.js
+++ b/src/js/components/wonderland/Video.js
@@ -116,6 +116,12 @@ var Video = React.createClass({
                 }
             }
         ;
+        // If the video is 'serving' or 'failed', its going nowhere, so don't
+        // bother checking
+        if (self.state.videoState === 'serving' || self.state.videoState === 'failed') {
+            clearInterval(self.timer);
+            return false;
+        }
         self.setState({
             isBusy: true
         }, function() {
@@ -125,14 +131,6 @@ var Video = React.createClass({
                         return;
                     }
                     var video = json.videos[0];
-                    if ((video.state === 'serving' && self.state.videoState === 'serving') || (video.state === 'failed' && self.state.videoState === 'failed')) {
-                        self.setState({
-                            isBusy: false,
-                        }, function() {
-                            clearInterval(self.timer);
-                        });
-                        return false;
-                    }
                     if (video.state !== self.state.videoState) {
                         // Only bother if the state has changed
                         self.setState({

--- a/src/js/modules/ajax.js
+++ b/src/js/modules/ajax.js
@@ -56,7 +56,6 @@ var AJAX = {
                         })
                             .then(function (res) {
                                 self.Session.set(res.access_token, res.refresh_token, res.account_ids[0]);
-                                debugger;
                                 fin(resolve, reject);
                             })
                             .catch(function (err) {


### PR DESCRIPTION
- removed debugger
- moved double status check out of AJAX call and preemptively check if
  the status is serving or failed, if it is, give up, clear the timer
  (don’t check again) and return
