### PR TITLE
Video component - expand/contract #881

### DIFF
--- a/docs/CREDENTIALS.md
+++ b/docs/CREDENTIALS.md
@@ -17,3 +17,8 @@
 - USERNAME = 'global_admin_neon'
 - PASSWORD = '4ERDWIlupafI'
 - ACCOUNT_ID = 'gvs3vytvg20ozp78rolqmdfa'
+
+## (Test) Fox
+
+- admin_fox
+- U7oMUyFefoEV1Wn1

--- a/src/js/components/wonderland/VideoHeader.js
+++ b/src/js/components/wonderland/VideoHeader.js
@@ -18,7 +18,7 @@ var VideoHeader = React.createClass({
     },
     render: function() {
         var self = this,
-            toggleButtonContent = self.props.forceOpen ? '\u2191' : '\u2193',
+            toggleButtonContent = self.props.forceOpen ? <i className="fa fa-chevron-down"></i> : <i className="fa fa-chevron-up"></i>,
             toggleButton = <a className="button" onClick={self.handleToggle}>{toggleButtonContent}</a>, 
             title = '',
             videoTranslatedState = T.get('copy.' + self.props.videoState + 'State')


### PR DESCRIPTION
- added the Fox (test) credentials for future reference
- used some Font Awesome chevrons for the Video Header expand/contract
  toggle
- reversed the arrow logic
