### PR TITLE
Remove enable/disable of thumbnails (account.serving) #916

### DIFF
--- a/src/css/components/_thumbbox.scss
+++ b/src/css/components/_thumbbox.scss
@@ -15,6 +15,12 @@ $transition: all 0.3333s;
     .wonderland-thumbnail:hover & { // hack
         transform: translateX(0);
     }
+    .modal & {
+        transform: none;
+        .wonderland-thumbnail:hover & { // hack
+            transform: none;
+        }
+    }
 }
 
 .wonderland-thumbbox__tools {
@@ -38,6 +44,13 @@ $transition: all 0.3333s;
     color: rgba(#fff, 0.7777);
     &:hover {
         color: #fff;
+    }
+    &.-disabled {
+        color: rgba(#fff, 0.2);
+        cursor: not-allowed;
+        &:hover {
+            color: rgba(#fff, 0.2);
+        }
     }
     .fa {
         font-size: 0.618em; // hack

--- a/src/js/components/core/ImageModal.js
+++ b/src/js/components/core/ImageModal.js
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import ThumbBox from '../wonderland/ThumbBox';
+import UTILS from '../../modules/utils';
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -17,7 +18,7 @@ var ImageModal = React.createClass({
     },
     render: function() {
         var self = this,
-            indicator = self.props.isEnabled ? 'fa-check' : 'fa-times'
+            enabledIndicator = UTILS.enabledDisabledIcon(self.props.isEnabled)
         ;
         return (
             <figure className="wonderland-thumbnail">
@@ -29,12 +30,13 @@ var ImageModal = React.createClass({
                 />
                 <figcaption className="wonderland-thumbnail__caption">
                     <span className="wonderland-thumbnail__indicator -background"><i className="fa fa-circle"></i></span>
-                    <span className="wonderland-thumbnail__indicator -foreground"><i className={'fa ' + indicator}></i></span>
+                    <span className="wonderland-thumbnail__indicator -foreground"><i className={'fa fa-' + enabledIndicator}></i></span>
                     <ThumbBox
                         copyUrl={self.props.copyUrl}
                         downloadUrl={self.props.downloadUrl}
                         isEnabled={self.props.isEnabled}
                         handleEnabledChange={self.props.handleEnabledChange}
+                        isAccountServingEnabled={self.props.isAccountServingEnabled}
                     />
                 </figcaption>
             </figure>

--- a/src/js/components/pages/VideoPage.js
+++ b/src/js/components/pages/VideoPage.js
@@ -6,12 +6,13 @@ import SiteFooter from '../wonderland/SiteFooter';
 import Video from '../wonderland/Video';
 import Secured from '../../mixins/secured';
 import Helmet from 'react-helmet';
+import Account from '../../mixins/Account';
 import UTILS from '../../modules/utils';
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
 var VideoPage = React.createClass({
-    mixins: [Secured],
+    mixins: [Secured, Account],
     contextTypes: {
         router: React.PropTypes.object.isRequired
     },
@@ -33,6 +34,7 @@ var VideoPage = React.createClass({
                             pingInitial={true}
                             pingInterval={true}
                             forceOpen={true}
+                            isAccountServingEnabled={self.state.isAccountServingEnabled}
                         />
                     </div>
                 </section>

--- a/src/js/components/pages/VideosPage.js
+++ b/src/js/components/pages/VideosPage.js
@@ -6,18 +6,20 @@ import UTILS from '../../modules/utils';
 import SiteHeader from '../wonderland/SiteHeader';
 import SiteFooter from '../wonderland/SiteFooter';
 import Videos from '../wonderland/Videos';
+import Account from '../../mixins/Account';
 import Secured from '../../mixins/secured';
 import T from '../../modules/translation';
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
 var VideosPage = React.createClass({
-    mixins: [Secured],
+    mixins: [Secured, Account],
     contextTypes: {
         router: React.PropTypes.object.isRequired
     },
     render: function() {
-        var heading = T.get('copy.videosPage.heading'),
+        var self = this,
+            heading = T.get('copy.videosPage.heading'),
             body = T.get('copy.videosPage.body', {
                 // '@username': 'TODO'
             })
@@ -34,7 +36,9 @@ var VideosPage = React.createClass({
                         <div className="content">
                             {body}
                         </div>
-                        <Videos />
+                        <Videos
+                            isAccountServingEnabled={self.state.isAccountServingEnabled}
+                        />
                     </div>
                 </section>
                 <SiteFooter />

--- a/src/js/components/wonderland/SiteBanner.js
+++ b/src/js/components/wonderland/SiteBanner.js
@@ -17,15 +17,17 @@ var SiteBanner = React.createClass({
         if (SESSION.active()) {
             SESSION.user()
                 .then(function(userData) {
-                    if (userData.first_name) {
-                        self.setState({
-                            displayName: userData.first_name
-                        });
-                    }
-                    else {
-                        self.setState({
-                            displayName: userData.username
-                        });
+                    if (userData) {
+                        if (userData.first_name) {
+                            self.setState({
+                                displayName: userData.first_name
+                            });
+                        }
+                        else {
+                            self.setState({
+                                displayName: userData.username
+                            });
+                        }
                     }
                 })
                 .catch(function(err) {

--- a/src/js/components/wonderland/Slide.js
+++ b/src/js/components/wonderland/Slide.js
@@ -7,7 +7,7 @@ import React from 'react';
 var Slide = React.createClass({
     propTypes: {
         icon: React.PropTypes.string.isRequired,
-        slideContent:  React.PropTypes.string.isRequired
+        slideContent: React.PropTypes.string.isRequired
     },
     render: function() {
         var self = this;  

--- a/src/js/components/wonderland/ThumbBox.js
+++ b/src/js/components/wonderland/ThumbBox.js
@@ -1,6 +1,7 @@
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
 import React from 'react';
+import UTILS from '../../modules/utils';
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
@@ -20,8 +21,9 @@ var ThumbBox = React.createClass({
     render: function() {
         var self = this,
             toggleModalButton = '',
-            isEnabledIndicator = 'fa ' + (!self.props.isEnabled ? 'fa-check' : 'fa-times'),
-            enabledTooltip = (!self.props.isEnabled ? 'Enable this Thumbnail' : 'Disable this Thumbnail')
+            enabledIndicator = UTILS.enabledDisabledIcon(!self.props.isEnabled), // we want the opposite
+            enabledTooltip = self.props.isAccountServingEnabled ? (!self.props.isEnabled ? 'Enable this Thumbnail' : 'Disable this Thumbnail') : 'Serving is Disabled for this Account',
+            enabledDisabledClass = self.props.isAccountServingEnabled ? '' : ' -disabled'
         ;
         if (self.props.handleToggleModal) {
             toggleModalButton = function() {
@@ -46,10 +48,10 @@ var ThumbBox = React.createClass({
                     </span>
                     <span
                         title={enabledTooltip}
-                        className="icon wonderland-thumbbox__tool"
+                        className={'icon wonderland-thumbbox__tool' + enabledDisabledClass}
                         onClick={self.props.handleEnabledChange}
                     >
-                        <i className={isEnabledIndicator} aria-hidden="true"></i>
+                        <i className={'fa fa-' + enabledIndicator} aria-hidden="true"></i>
                     </span>
                     <a
                         href={self.props.downloadUrl}

--- a/src/js/components/wonderland/Thumbnail.js
+++ b/src/js/components/wonderland/Thumbnail.js
@@ -25,6 +25,7 @@ var Thumbnail = React.createClass({
         url: React.PropTypes.string.isRequired,
         strippedUrl: React.PropTypes.string.isRequired,
         forceOpen: React.PropTypes.bool.isRequired,
+        isAccountServingEnabled: React.PropTypes.bool.isRequired
     },
     getInitialState: function () {
         var self = this;
@@ -61,8 +62,9 @@ var Thumbnail = React.createClass({
             src = (self.props.forceOpen ? self.props.strippedUrl : '/img/clear.gif'),
             dataSrc = (self.props.forceOpen ? '' : self.props.strippedUrl),
             figureClassName = 'wonderland-thumbnail ' + (self.state.isEnabled ? 'is-wonderland-enabled' : 'is-wonderland-disabled'),
-            indicator = self.state.isEnabled ? 'fa-check' : 'fa-times',
-            neonScore = UTILS.NEON_SCORE_ENABLED ? <span className={additionalClass} title={T.get('neonScore')}>{self.props.cookedNeonScore}</span> : ''
+            enabledIndicator = UTILS.enabledDisabledIcon(self.state.isEnabled), // we want the opposite
+            neonScore = UTILS.NEON_SCORE_ENABLED ? <span className={additionalClass} title={T.get('neonScore')}>{self.props.cookedNeonScore}</span> : '',
+            handleEnabledChangeHook = self.props.isAccountServingEnabled ? self.handleEnabledChange : function() { return false; }
         ;
         return (
             <figure
@@ -84,15 +86,16 @@ var Thumbnail = React.createClass({
                 />
                 <figcaption className="wonderland-thumbnail__caption">
                     {neonScore}
-                    <input className="wonderland-thumbnail__enabled is-medium" onChange={self.handleEnabledChange} checked={self.state.isEnabled} type="checkbox" disabled={enabledDisabled} />
-                    <span className="wonderland-thumbnail__indicator -background"><i className="fa fa-circle"></i></span>
-                    <span className="wonderland-thumbnail__indicator -foreground"><i className={'fa ' + indicator}></i></span>
+                    <input className="wonderland-thumbnail__enabled is-medium" onChange={handleEnabledChangeHook} checked={self.state.isEnabled} type="checkbox" disabled={enabledDisabled} />
+                    <span onClick={self.handleToggleModal} className="wonderland-thumbnail__indicator -background"><i className="fa fa-circle"></i></span>
+                    <span onClick={self.handleToggleModal} className="wonderland-thumbnail__indicator -foreground"><i className={'fa fa-' + enabledIndicator}></i></span>
                     <ThumbBox
                         copyUrl={self.props.url}
                         downloadUrl={self.props.url}
                         isEnabled={self.state.isEnabled}
                         handleToggleModal={self.handleToggleModal}
-                        handleEnabledChange={self.handleEnabledChange}
+                        handleEnabledChange={handleEnabledChangeHook}
+                        isAccountServingEnabled={self.props.isAccountServingEnabled}
                     />
                 </figcaption>
                 <ModalWrapper isModalActive={self.state.isModalActive} handleToggleModal={self.handleToggleModal}>
@@ -102,7 +105,8 @@ var Thumbnail = React.createClass({
                         copyUrl={self.props.url}
                         downloadUrl={self.props.url}
                         isEnabled={self.state.isEnabled}
-                        handleEnabledChange={self.handleEnabledChange}
+                        handleEnabledChange={handleEnabledChangeHook}
+                        isAccountServingEnabled={self.props.isAccountServingEnabled}
                     />
                 </ModalWrapper>
             </figure>

--- a/src/js/components/wonderland/Thumbnails.js
+++ b/src/js/components/wonderland/Thumbnails.js
@@ -15,8 +15,9 @@ var Thumbnails = React.createClass({
     propTypes: {
         videoState: React.PropTypes.string.isRequired,
         videoStateMapping: React.PropTypes.string.isRequired,
-        thumbnails:  React.PropTypes.array.isRequired,
-        forceOpen:  React.PropTypes.bool.isRequired
+        thumbnails: React.PropTypes.array.isRequired,
+        forceOpen: React.PropTypes.bool.isRequired,
+        isAccountServingEnabled: React.PropTypes.bool.isRequired
     },
     render: function() {
         var self = this;
@@ -57,6 +58,7 @@ var Thumbnails = React.createClass({
                                             thumbnailId={thumbnail.thumbnail_id}
                                             type={thumbnail.type}
                                             forceOpen={self.props.forceOpen}
+                                            isAccountServingEnabled={self.props.isAccountServingEnabled}
                                         />
                                     </div>
                                 );

--- a/src/js/components/wonderland/Video.js
+++ b/src/js/components/wonderland/Video.js
@@ -101,6 +101,7 @@ var Video = React.createClass({
                         videoLink={videoLink}
                         duration={self.state.duration || 0}
                         url={self.state.url}
+                        isAccountServingEnabled={self.props.isAccountServingEnabled}
                     />
                 </div>
             );
@@ -108,7 +109,6 @@ var Video = React.createClass({
     },
     handleVideoOpenToggle: function(e) {
         e.preventDefault();
-        console.log('handleVideoOpenToggle');
         var self = this;
         self.setState({
             forceOpen: !self.state.forceOpen

--- a/src/js/components/wonderland/VideoMain.js
+++ b/src/js/components/wonderland/VideoMain.js
@@ -14,7 +14,8 @@ var VideoMain = React.createClass({
         videoState: React.PropTypes.string.isRequired,
         videoLink: React.PropTypes.string.isRequired,
         duration: React.PropTypes.number.isRequired,
-        url: React.PropTypes.string.isRequired
+        url: React.PropTypes.string.isRequired,
+        isAccountServingEnabled: React.PropTypes.bool.isRequired
     },
     render: function() {
         var self = this,
@@ -31,6 +32,7 @@ var VideoMain = React.createClass({
                             thumbnails={self.props.thumbnails}
                             videoState={self.props.videoState}
                             forceOpen={self.props.forceOpen}
+                            isAccountServingEnabled={self.props.isAccountServingEnabled}
                         />
                     </div>
                     <div className="column is-2">

--- a/src/js/components/wonderland/Videos.js
+++ b/src/js/components/wonderland/Videos.js
@@ -56,6 +56,7 @@ var Videos = React.createClass({
                     referrer={self.state.referrer}
                     videoCountServed={self.state.videoCountServed}
                     videoCountRequested={UTILS.VIDEO_PAGE_SIZE}
+                    isAccountServingEnabled={self.props.isAccountServingEnabled}
                 />
             </div>
         );

--- a/src/js/components/wonderland/VideosResults.js
+++ b/src/js/components/wonderland/VideosResults.js
@@ -48,6 +48,7 @@ var VideosResults = React.createClass({
                                             // publish_date
                                             // updated
                                             created={video.created}
+                                            isAccountServingEnabled={self.props.isAccountServingEnabled}
                                         />
                                     </td>
                                 </tr>

--- a/src/js/mixins/Account.js
+++ b/src/js/mixins/Account.js
@@ -1,0 +1,36 @@
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
+import AJAX from '../modules/ajax';
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
+var Account = {
+    getInitialState: function() {
+        return {
+            account: {},
+            isAccountServingEnabled: false
+        }
+    },
+    componentWillMount: function() {
+        var self = this,
+            options = {}
+        ;
+        AJAX.doGet('', options)
+            .then(function(res) {
+                self.setState({
+                    account: res.account,
+                    isAccountServingEnabled: res.account ? (res.account.serving_enabled ? !!res.account.serving_enabled : false) : false
+                })
+            })
+            .catch(function(err) {
+                console.log(err);
+            })
+        ;
+    }
+};
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
+export default Account;
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

--- a/src/js/modules/utils.js
+++ b/src/js/modules/utils.js
@@ -149,6 +149,9 @@ var UTILS = {
     rando: function(num) {
         return Math.floor(Math.random() * num + 1);
     },
+    enabledDisabledIcon: function(enabled) {
+        return enabled ? 'check' : 'times';
+    },
     generateId: function() {
         var id = shortid.generate(),
             hash64 = fnv.hash(id + Date.now(), 128)


### PR DESCRIPTION
- created new Account mixin (WIP) to get account details and
  specifically `isAccountServingEnabled`, added to `VideosPage` and `VideoPage`
- prop `isAccountServingEnabled` passed around
- extra whitespace
- catching case in `SiteBanner` where no `userData` comes back
- added `enabledDisabledIcon` function
- missing `self` reference
- wiring up call so that if serving is disabled for the account, none
  of the enabled/disabled clicks/events fire
- dead `console.log`
- added a disabled class for thumbnail indicators (for when there is no
  serving)
