### PR TITLE
Upgrade Bulma and killing the Modal #943

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "babel-polyfill": "^6.7.2",
-    "bulma": "0.0.16",
+    "bulma": "0.0.23",
     "clipboard": "^1.5.10",
     "fnv-plus": "^1.2.12",
     "font-awesome": "^4.5.0",

--- a/src/css/components/_banner.scss
+++ b/src/css/components/_banner.scss
@@ -34,6 +34,24 @@ $smallest-ratio: 0.191;
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
+.wonderland-banner--footer {
+    color: $grey-light;
+    a {
+        color: $grey-light; 
+        &:link,
+        &:visited {
+            color: $grey-light; 
+        }
+        &:focus,
+        &:hover,
+        &:active {
+            color: $white; 
+        }
+    }
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
 .wonderland-navbar {
     height: $maximum-nav-height;
 }
@@ -145,6 +163,49 @@ $smallest-ratio: 0.191;
     .fa {
         font-size: $maximum-nav-height * 0.5;
     }
+    &:focus,
+    &:hover,
+    &:active {
+        color: $white; 
+    }
+    &.wonderland-active {
+        border-bottom: 4px solid $orange;
+    }
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
+.wonderland-navbar__icon {
+    transition: color 0.3333s;
+    border-radius: 50%;
+    width: $maximum-nav-height * $smaller-ratio;
+    height: $maximum-nav-height * $smaller-ratio;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    .fa {
+        font-size: $maximum-nav-height * 0.5;
+    }
+}
+
+.wonderland-navbar__icon--regular {
+    color: $grey;
+    &:focus,
+    &:hover,
+    &:active {
+        color: $white;
+    }
+}
+
+.wonderland-navbar__icon--alternate {
+    background-color: $white;
+    color: $grey;
+    &:focus,
+    &:hover,
+    &:active {
+        color: $grey-darker;
+    }
+
 }
 
 .wonderland-navbar__icon--regular {

--- a/src/css/components/_checkbox.scss
+++ b/src/css/components/_checkbox.scss
@@ -1,0 +1,10 @@
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
+.wonderland-checkbox {
+}
+
+.wonderland-checkbox--checkbox {
+    margin-right: 0.5em;
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

--- a/src/css/components/_thumbnail.scss
+++ b/src/css/components/_thumbnail.scss
@@ -47,9 +47,6 @@
             color: $danger;
         }
     }
-    &.-background {
-        display: none;
-    }
     .is-wonderland-enabled & {
         opacity: 0;
     }

--- a/src/css/wonderland.scss
+++ b/src/css/wonderland.scss
@@ -4,11 +4,7 @@
 
 @charset 'UTF-8';
 
-// 0. Bulma
-@import '../../node_modules/bulma/bulma/utilities/utilities';
-@import '../../node_modules/bulma/bulma/config/variables';
-
-// Ours
+// Neon
 $curious-blue: #26a9e0;
 $flamingo: #f16122;
 $gray: #888;
@@ -24,20 +20,18 @@ $grey-dark: $gray;
 $grey: $silver-chalice;
 $grey-light: mix($silver-chalice, $athens-gray, 25%);
 $grey-lighter: $athens-gray;
-
 $family-sans-serif: "Open Sans", sans-serif;
-
 $primary: $blue;
 $red: $orange;
 $body-background: $white;
 $background: $white;
 
-@import '../../node_modules/bulma/bulma/config/generated-variables';
-
-@import '../../node_modules/bulma/bulma/base/base';
-@import '../../node_modules/bulma/bulma/elements/elements';
-@import '../../node_modules/bulma/bulma/components/components';
-@import '../../node_modules/bulma/bulma/layout/layout';
+@import '../../node_modules/bulma/sass/utilities/utilities';
+@import "../../node_modules/bulma/sass/utilities/variables";
+@import '../../node_modules/bulma/sass/base/base';
+@import '../../node_modules/bulma/sass/elements/elements';
+@import '../../node_modules/bulma/sass/components/components';
+@import '../../node_modules/bulma/sass/layout/layout';
 
 // 1. Configuration and helpers
 @import
@@ -70,6 +64,7 @@ $background: $white;
     'components/thumbbox',
     'components/slides',
     'components/infobox',
+    'components/checkbox',
     'components/modal',
     'components/xylophone',
     'components/banner'

--- a/src/js/components/core/ImageModal.js
+++ b/src/js/components/core/ImageModal.js
@@ -34,7 +34,6 @@ var ImageModalChild = React.createClass({
                             title={self.props.caption}
                         />
                         <figcaption className="wonderland-thumbnail__caption">
-                            <span className="wonderland-thumbnail__indicator -background"><i className="fa fa-circle"></i></span>
                             <span className="wonderland-thumbnail__indicator -foreground"><i className={'fa fa-' + enabledIndicator}></i></span>
                             <ThumbBox
                                 copyUrl={self.props.copyUrl}

--- a/src/js/components/core/ImageModalChild.js
+++ b/src/js/components/core/ImageModalChild.js
@@ -40,7 +40,6 @@ var ImageModalChild = React.createClass({
                             title={self.props.caption}
                         />
                         <figcaption className="wonderland-thumbnail__caption">
-                            <span className="wonderland-thumbnail__indicator -background"><i className="fa fa-circle"></i></span>
                             <span className="wonderland-thumbnail__indicator -foreground"><i className={'fa fa-' + enabledIndicator}></i></span>
                             <ThumbBox
                                 copyUrl={self.props.copyUrl}

--- a/src/js/components/core/ModalParent.js
+++ b/src/js/components/core/ModalParent.js
@@ -11,16 +11,18 @@ var ModalParent = React.createClass({
     },
     handleEscKey:function(e) {
         var self = this;
-        if (e.keyCode === 27) {
+        if (e.keyCode === 27 && self.props.isModalActive) {
             e.preventDefault();
             self.handleToggleModal(e);
         }
     },
-    componentWillMount:function(){
-        document.addEventListener("keydown", this.handleEscKey, false);
+    componentWillMount:function() {
+        var self = this;
+        document.addEventListener('keydown', self.handleEscKey, false);
     },
     componentWillUnmount: function() {
-        document.removeEventListener("keydown", this.handleEscKey, false);
+        var self = this;
+        document.removeEventListener('keydown', self.handleEscKey, false);
     },
     render: function() {
         var self = this,

--- a/src/js/components/forms/AnalyzeVideoForm.js
+++ b/src/js/components/forms/AnalyzeVideoForm.js
@@ -97,7 +97,7 @@ var AnalyzeVideoForm = React.createClass({
                                 placeholder={T.get('analyze.optionalTitle')}
                             />
                         </p>
-                        <p className="is-text-centered">
+                        <p className="has-text-centered">
                             <button className={buttonClassName} type="submit">
                                 <i className="fa fa-eye" aria-hidden="true"></i> {T.get('analyze')}
                             </button>

--- a/src/js/components/forms/ForgotPasswordForm.js
+++ b/src/js/components/forms/ForgotPasswordForm.js
@@ -34,7 +34,7 @@ var ForgotPasswordForm = React.createClass({
                         <p className="control">
                             <input className="input is-medium" type="email" ref="email" placeholder={T.get('email')} />
                         </p>
-                        <p className="is-text-centered">
+                        <p className="has-text-centered">
                             <button className="button is-medium is-primary" type="submit">{T.get('reset.sendReset')}</button>
                         </p>
                     </fieldset>

--- a/src/js/components/forms/IntegrationsForm.js
+++ b/src/js/components/forms/IntegrationsForm.js
@@ -6,7 +6,7 @@ import UTILS from '../../modules/utils';
 import T from '../../modules/translation';
 import Message from '../wonderland/Message';
 import E from '../../modules/errors';
-import ModalWrapper from '../core/ModalParent';
+import ModalParent from '../core/ModalParent';
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -107,7 +107,7 @@ var IntegrationsForm = React.createClass({
                             </div>
                         </fieldset>
                     </form>
-                    <ModalWrapper isModalActive={(self.state.activeModal === 'brightcove-publisherId')} handleToggleModal={self.closeModal}>
+                    <ModalParent isModalActive={(self.state.activeModal === 'brightcove-publisherId')} handleToggleModal={self.closeModal}>
                         <section className="box is-desktop">
                             <h1 className="title is-4">
                                 How to locate your Publisher ID
@@ -123,8 +123,8 @@ var IntegrationsForm = React.createClass({
                                 </ol>
                             </div>
                         </section>
-                    </ModalWrapper>
-                    <ModalWrapper isModalActive={(self.state.activeModal === 'brightcove-readToken')} handleToggleModal={self.closeModal}>
+                    </ModalParent>
+                    <ModalParent isModalActive={(self.state.activeModal === 'brightcove-readToken')} handleToggleModal={self.closeModal}>
                         <section className="box is-desktop">
                             <h1 className="title is-4">
                                 How to locate your Read Token with URL access
@@ -146,8 +146,8 @@ var IntegrationsForm = React.createClass({
                                 Note: You may have multiple Read Tokens with URL Access if you or someone on your team has engaged in API management tasks in the past. You can use any Read Token as long as the one you pick has URL Access.
                             </div>
                         </section>
-                    </ModalWrapper>
-                    <ModalWrapper isModalActive={(self.state.activeModal === 'brightcove-writeToken')} handleToggleModal={self.closeModal}>
+                    </ModalParent>
+                    <ModalParent isModalActive={(self.state.activeModal === 'brightcove-writeToken')} handleToggleModal={self.closeModal}>
                         <section className="box is-desktop">
                             <h1 className="title is-4">
                                 How to locate your Write Token
@@ -169,7 +169,7 @@ var IntegrationsForm = React.createClass({
                                 </ol>
                             </div>
                         </section>
-                    </ModalWrapper>
+                    </ModalParent>
                 </div>
             );
         case 'ooyala':

--- a/src/js/components/forms/SignInForm.js
+++ b/src/js/components/forms/SignInForm.js
@@ -72,12 +72,12 @@ var SignInForm = React.createClass({
                         <input className={inputClassName} type="password" required ref="password" placeholder={T.get('password')} />
                     </p>
                     <p className="control">
-                        <label className="checkbox is-medium" htmlFor="isRememberMe">
-                            <input className="checkbox" type="checkbox" ref="isRememberMe" id="isRememberMe" defaultValue={SESSION.rememberMe()} defaultChecked={SESSION.rememberMe()} />
+                        <label className="checkbox" htmlFor="isRememberMe">
+                            <input type="checkbox" className="wonderland-checkbox--checkbox" ref="isRememberMe" id="isRememberMe" defaultValue={SESSION.rememberMe()} defaultChecked={SESSION.rememberMe()} />
                             {T.get('rememberMe')}
                         </label>
                     </p>
-                    <p className="is-text-centered">
+                    <p className="has-text-centered">
                         <button className={buttonClassName} type="submit">{T.get('signIn')}</button>
                     </p>
                 </fieldset>

--- a/src/js/components/forms/SignUpForm.js
+++ b/src/js/components/forms/SignUpForm.js
@@ -85,12 +85,12 @@ var SignUpForm = React.createClass({
                         <input className="input is-medium" type="text" ref="title" placeholder={T.get('title')} />
                     </p>
                     <p className="control">
-                        <label className="checkbox is-medium">
-                            <input type="checkbox" required onChange={self.handleAgreementChange} checked={self.state.isAgreementChecked} />
+                        <label className="checkbox">
+                            <input className="wonderland-checkbox--checkbox" type="checkbox" required onChange={self.handleAgreementChange} checked={self.state.isAgreementChecked} />
                             <span dangerouslySetInnerHTML={{__html: copyTerms}} />
                         </label>
                     </p>
-                    <p className="is-text-centered">
+                    <p className="has-text-centered">
                         <button className={buttonClassName} type="submit">{T.get('signUp')}</button>
                     </p>
                 </fieldset>

--- a/src/js/components/pages/AccountConfirmedPage.js
+++ b/src/js/components/pages/AccountConfirmedPage.js
@@ -24,7 +24,7 @@ var AccountConfirmedPage = React.createClass({
                 <SiteHeader />
                 <section className="section">
                     <div className="columns is-desktop">
-                        <div className="column is-half is-offset-quarter">
+                        <div className="column is-half is-offset-one-quarter">
                            <h1 className="title is-2">{T.get('copy.accountConfirmed.heading')}</h1>
                             <div className="content">
                                 <p><span dangerouslySetInnerHTML={{__html: body}} /></p>

--- a/src/js/components/pages/AnalyzeVideoPage.js
+++ b/src/js/components/pages/AnalyzeVideoPage.js
@@ -25,7 +25,7 @@ var AnalyzeVideoPage = React.createClass({
                 <SiteHeader />
                 <section className="section">
                     <div className="columns is-desktop">
-                        <div className="column is-half is-offset-quarter">
+                        <div className="column is-half is-offset-one-quarter">
                             <h1 className="title is-2">{T.get('copy.analyzeVideo.heading')}</h1>
                             {/*<div className="content">
                                 <p>{T.get('copy.analyzeVideo.body')}</p>

--- a/src/js/components/pages/ConfirmAccountPage.js
+++ b/src/js/components/pages/ConfirmAccountPage.js
@@ -67,7 +67,7 @@ var ConfirmAccountPage = React.createClass({
                 <SiteHeader />
                 <section className="section">
                     <div className="columns is-desktop">
-                        <div className="column is-half is-offset-quarter">
+                        <div className="column is-half is-offset-one-quarter">
                             {messageNeeded}
                             <h1 className="title is-2">{T.get('copy.confirmAccount.heading')}</h1>
                             <div className="content">

--- a/src/js/components/pages/DashboardPage.js
+++ b/src/js/components/pages/DashboardPage.js
@@ -23,7 +23,7 @@ var DashboardPage = React.createClass({
                 <SiteHeader />
                 <section className="section">
                     <div className="columns is-desktop">
-                        <div className="column is-half is-offset-quarter">
+                        <div className="column is-half is-offset-one-quarter">
                             TODO - DashboardPage
                         </div>
                     </div>

--- a/src/js/components/pages/ForgotPasswordPage.js
+++ b/src/js/components/pages/ForgotPasswordPage.js
@@ -20,7 +20,7 @@ var ForgotPasswordPage = React.createClass({
                 <SiteHeader />
                 <section className="section">
                     <div className="columns is-desktop">
-                        <div className="column is-half is-offset-quarter">
+                        <div className="column is-half is-offset-one-quarter">
                             <h1 className="title is-2">{T.get('copy.forgotPassword.heading')}</h1>
                             <div className="content">
                                 <p>{T.get('copy.forgotPassword.body')}</p>

--- a/src/js/components/pages/HomePage.js
+++ b/src/js/components/pages/HomePage.js
@@ -19,7 +19,7 @@ var HomePage = React.createClass({
                 <SiteHeader />
                 <section className="section">
                     <div className="columns is-desktop">
-                        <div className="column is-half is-offset-quarter">
+                        <div className="column is-half is-offset-one-quarter">
                             <p>TODO</p>
                         </div>
                     </div>

--- a/src/js/components/pages/IntegrationsBrightcovePage.js
+++ b/src/js/components/pages/IntegrationsBrightcovePage.js
@@ -30,7 +30,7 @@ var IntegrationsBrightcovePage = React.createClass({
                 <SiteHeader />
                 <section className="section">
                     <div className="columns is-desktop">
-                        <div className="column is-half is-offset-quarter">
+                        <div className="column is-half is-offset-one-quarter">
                             <h1 className="title is-2">
                                 <img src={T.get('copy.integrations.types.brightcove.img')} />
                             </h1>

--- a/src/js/components/pages/IntegrationsNewPage.js
+++ b/src/js/components/pages/IntegrationsNewPage.js
@@ -32,8 +32,8 @@ var IntegrationsNewPage = React.createClass({
                             {T.get('copy.integrations.new.body')}
                         </div>
                         <div className="columns">
-                            <div className="card column is-third">
-                                <div className="card-content is-text-centered">
+                            <div className="card column is-one-third">
+                                <div className="card-content has-text-centered">
                                     <img src={T.get('copy.integrations.types.brightcove.img')} />
                                     <div>
                                         <a className="button is-primary is-medium" onClick={this.addBrightcove}>{T.get('add')}</a>

--- a/src/js/components/pages/NewIntegrationPage.js
+++ b/src/js/components/pages/NewIntegrationPage.js
@@ -32,8 +32,8 @@ var NewIntegrationPage = React.createClass({
                             {T.get('copy.new.integration.body')}
                         </div>
                         <div className="columns">
-                            <div className="card column is-third">
-                                <div className="card-content is-text-centered">
+                            <div className="card column is-one-third">
+                                <div className="card-content has-text-centered">
                                     <img src={T.get('copy.integrations.types.brightcove.img')} />
                                     <div>
                                         <a className="button is-primary is-medium" onClick={this.addBrightcove}>{T.get('add')}</a>

--- a/src/js/components/pages/NotFoundPage.js
+++ b/src/js/components/pages/NotFoundPage.js
@@ -25,7 +25,7 @@ var NotFoundPage = React.createClass({
                 <SiteHeader />
                 <section className="section">
                     <div className="columns is-desktop">
-                        <div className="column is-half is-offset-quarter">
+                        <div className="column is-half is-offset-one-quarter">
                             <h1 className="title is-2">{T.get('copy.notFound.heading')}</h1>
                             <div className="content">
                                 <p><span dangerouslySetInnerHTML={{__html: body1}} /></p>

--- a/src/js/components/pages/PendingAccountPage.js
+++ b/src/js/components/pages/PendingAccountPage.js
@@ -25,7 +25,7 @@ var PendingAccountPage = React.createClass({
                 <SiteHeader />
                 <section className="section">
                     <div className="columns is-desktop">
-                        <div className="column is-half is-offset-quarter">
+                        <div className="column is-half is-offset-one-quarter">
                             <h1 className="title is-2">{T.get('copy.pendingAccount.heading')}</h1>
                             <div className="content">
                                 <p><span dangerouslySetInnerHTML={{__html: body1}} /></p>

--- a/src/js/components/pages/SignInPage.js
+++ b/src/js/components/pages/SignInPage.js
@@ -33,7 +33,7 @@ var SignInPage = React.createClass({
                 <SiteHeader />
                 <section className="section">
                     <div className="columns is-desktop">
-                        <div className="column is-half is-offset-quarter">
+                        <div className="column is-half is-offset-one-quarter">
                             <h1 className="title is-2">{T.get('copy.signIn.heading')}</h1>
                             <div className="content">
                                 {/*<p>{T.get('copy.signIn.body')}</p>*/}

--- a/src/js/components/pages/SignOutPage.js
+++ b/src/js/components/pages/SignOutPage.js
@@ -34,7 +34,7 @@ var SignOutPage = React.createClass({
                 <SiteHeader />
                 <section className="section">
                     <div className="columns is-desktop">
-                        <div className="column is-half is-offset-quarter">
+                        <div className="column is-half is-offset-one-quarter">
                             <h1 className="title is-2">{heading}</h1>
                             <div className="content">
                                 <p><span dangerouslySetInnerHTML={{__html: body}} /></p>

--- a/src/js/components/pages/SignUpPage.js
+++ b/src/js/components/pages/SignUpPage.js
@@ -22,13 +22,15 @@ var SignUpPage = React.createClass({
                 />
                 <SiteHeader />
                 <section className="section">
-                    <div className="columns is-desktop">
-                        <div className="column is-half is-offset-quarter">
-                            <h1 className="title is-2">{heading}</h1>
-                            <div className="content">
-                                <p>{body}</p>
+                    <div className="container">
+                        <div className="columns is-desktop">
+                            <div className="column is-half is-offset-one-quarter">
+                                <h1 className="title is-2">{heading}</h1>
+                                <div className="content">
+                                    <p>{body}</p>
+                                </div>
+                                <SignUpForm showLegend={false} />
                             </div>
-                            <SignUpForm showLegend={false} />
                         </div>
                     </div>
                 </section>

--- a/src/js/components/pages/TermsPage.js
+++ b/src/js/components/pages/TermsPage.js
@@ -20,7 +20,7 @@ var TermsPage = React.createClass({
                 <SiteHeader />
                 <section className="section">
                     <div className="columns is-desktop">
-                        <div className="column is-half is-offset-quarter">
+                        <div className="column is-half is-offset-one-quarter">
                             <h1 className="title is-2">{T.get('copy.terms.heading')}</h1>
                             <TermsOfService />
                         </div>

--- a/src/js/components/wonderland/NewsFlash.js
+++ b/src/js/components/wonderland/NewsFlash.js
@@ -17,7 +17,7 @@ var NewsFlash = React.createClass({
         var self = this;
         if (self.props.isActive) {
             return (
-                <div className="notification is-danger is-marginless is-text-centered">
+                <div className="notification is-danger is-marginless has-text-centered">
                     {this.props.message}
                 </div>
             );

--- a/src/js/components/wonderland/SiteFooter.js
+++ b/src/js/components/wonderland/SiteFooter.js
@@ -16,7 +16,7 @@ var SiteFooter = React.createClass({
         return (
             <footer className="footer wonderland-banner wonderland-banner--footer">
                 <div className="container">
-                    <div className="content is-text-centered">
+                    <div className="content has-text-centered">
                         <p>{T.get('copy.copyright', {'@name': T.get('app.companyLongName')})}</p>
                         <p><Link activeClassName="wonderland-active" to="/terms/">{T.get('nav.terms')}</Link> | <a href={UTILS.CONTACT_EXTERNAL_URL}>{T.get('nav.contact')}</a></p>
                         <p>{T.get('app.appName') + ' v' + UTILS.VERSION + '.' + CONFIG.LABEL}</p>

--- a/src/js/components/wonderland/Slide.js
+++ b/src/js/components/wonderland/Slide.js
@@ -12,7 +12,7 @@ var Slide = React.createClass({
     render: function() {
         var self = this;  
             return (
-                <div className="wonderland-slides-slide box is-fullwidth is-text-centered">
+                <div className="wonderland-slides-slide box is-fullwidth has-text-centered">
                     <p className="icon is-large ">
                         <i className={'fa fa-' + self.props.icon}></i>
                     </p>

--- a/src/js/components/wonderland/Thumbnail.js
+++ b/src/js/components/wonderland/Thumbnail.js
@@ -92,8 +92,7 @@ var Thumbnail = React.createClass({
                 />
                 <figcaption className="wonderland-thumbnail__caption">
                     {neonScore}
-                    <input className="wonderland-thumbnail__enabled is-medium" onChange={handleEnabledChangeHook} checked={self.state.isEnabled} type="checkbox" disabled={enabledDisabled} />
-                    <span onClick={self.handleToggleModal} className="wonderland-thumbnail__indicator -background"><i className="fa fa-circle"></i></span>
+                    <input className="wonderland-thumbnail__enabled" onChange={handleEnabledChangeHook} checked={self.state.isEnabled} type="checkbox" disabled={enabledDisabled} />
                     <span onClick={self.handleToggleModal} className="wonderland-thumbnail__indicator -foreground"><i className={'fa fa-' + enabledIndicator}></i></span>
                     <ThumbBox
                         copyUrl={self.props.url}

--- a/src/js/components/wonderland/Thumbnails.js
+++ b/src/js/components/wonderland/Thumbnails.js
@@ -43,7 +43,7 @@ var Thumbnails = React.createClass({
                                     strippedUrl = UTILS.stripProtocol(thumbnail.url)
                                 ;
                                 return (
-                                    <div className="column is-half-mobile is-third-tablet is-third-desktop" key={thumbnail.thumbnail_id}>
+                                    <div className="column is-half-mobile is-one-third-tablet is-one-third-desktop" key={thumbnail.thumbnail_id}>
                                         <Thumbnail
                                             index={i}
                                             videoStateMapping={self.props.videoStateMapping}

--- a/src/js/components/wonderland/TutorialPanel.js
+++ b/src/js/components/wonderland/TutorialPanel.js
@@ -12,8 +12,8 @@ var TutorialPanel = React.createClass({
     render: function() {
         var self = this;
         return (
-            <div className="card column is-third">
-                <div className="card-content is-text-centered">
+            <div className="card column is-one-third">
+                <div className="card-content has-text-centered">
                     <div className="icon is-large">
                         <i className={'fa fa-' + self.props.icon}></i>
                     </div>


### PR DESCRIPTION
- upgraded Bulma from 0.0.16 to 0.0.23 and fixed corresponding things
  that now broke
- added new checkbox component to deal with our checkboxes
- removed markup and style for no-longer-used thing
- rejigged `wonderland.scss`
- `is-text-centered` -> `has-text-centered`
- removing unused `is-medium`s
- `is-offset-quarter` -> `is-offset-one-quarter`
- added missing `<div class=“container”> to sort layout out
- `is-third` -> `is-one-third`
- only close modal if its open
- `ModalWrapper` -> `ModalParent`
