### PR TITLE
Option to SPECIFY a Thumbnail URL during Analyze Video #949

### DIFF
--- a/src/css/abstracts/_mixins.scss
+++ b/src/css/abstracts/_mixins.scss
@@ -1,0 +1,9 @@
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
+@mixin x-truncate() {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

--- a/src/css/components/_infobox.scss
+++ b/src/css/components/_infobox.scss
@@ -9,6 +9,7 @@
 }
 
 .wonderland-dd {
+    @include x-truncate;
     padding-bottom: 1em;
 }
 

--- a/src/js/components/core/ModalParent.js
+++ b/src/js/components/core/ModalParent.js
@@ -9,12 +9,13 @@ var ModalParent = React.createClass({
 	// mixins: [ReactDebugMixin],
     propTypes: {
         isModalActive: React.PropTypes.bool.isRequired,
-        isModalContentClipped: React.PropTypes.bool.isRequired,
+        isModalContentClipped: React.PropTypes.bool,
         handleToggleModal: React.PropTypes.func.isRequired,
         isModalContentMax: React.PropTypes.bool
     },
     getDefaultProps: function() {
         return {
+            isModalContentClipped: false,
             isModalContentMax: false
         }
     },

--- a/src/js/components/core/ThumbnailModalChild.js
+++ b/src/js/components/core/ThumbnailModalChild.js
@@ -1,0 +1,80 @@
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+import React from 'react';
+import ReactDebugMixin from 'react-debug-mixin';
+import ThumbBox from '../wonderland/ThumbBox';
+import ThumbnailInfoBox from '../wonderland/ThumbnailInfoBox';
+import UTILS from '../../modules/utils';
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+var ThumbnailModalChild = React.createClass({
+    mixins: [ReactDebugMixin],
+    propTypes: {
+        caption: React.PropTypes.string.isRequired,
+        strippedUrl: React.PropTypes.string.isRequired,
+        copyUrl: React.PropTypes.string.isRequired,
+        downloadUrl: React.PropTypes.string.isRequired,
+        isEnabled: React.PropTypes.bool.isRequired,
+        handleToggleModal: React.PropTypes.func,
+        handleEnabledChange: React.PropTypes.func.isRequired,
+        type: React.PropTypes.string.isRequired,
+        frameNo: React.PropTypes.number,
+        width: React.PropTypes.number.isRequired,
+        height: React.PropTypes.number.isRequired,
+        thumbnailId: React.PropTypes.string.isRequired,
+        created: React.PropTypes.string.isRequired,
+        updated: React.PropTypes.string.isRequired,
+        ctr: React.PropTypes.oneOfType([React.PropTypes.number, React.PropTypes.string]),
+    },
+    render: function() {
+        var self = this,
+            enabledIndicator = UTILS.enabledDisabledIcon(self.props.isEnabled)
+        ;
+        return (
+            <div className="box">
+                <div className="columns">
+                    <div className="column is-9">
+                        <figure className="wonderland-thumbnail">
+                            <img
+                                className="wonderland-thumbnail__image"
+                                src={self.props.strippedUrl}
+                                alt={self.props.caption}
+                                title={self.props.caption}
+                            />
+                            <figcaption className="wonderland-thumbnail__caption">
+                                <span className="wonderland-thumbnail__indicator -foreground"><i className={'fa fa-' + enabledIndicator}></i></span>
+                                <ThumbBox
+                                    copyUrl={self.props.copyUrl}
+                                    downloadUrl={self.props.downloadUrl}
+                                    isEnabled={self.props.isEnabled}
+                                    handleEnabledChange={self.props.handleEnabledChange}
+                                    isServingEnabled={self.props.isServingEnabled}
+                                    type={self.props.type}
+                                />
+                            </figcaption>
+                        </figure>
+                    </div>
+                    <div className="column is-3">
+                        <ThumbnailInfoBox
+                            frameNo={self.props.frameNo}
+                            type={self.props.type}
+                            width={self.props.width}
+                            height={self.props.height}
+                            thumbnailId={self.props.thumbnailId}
+                            created={self.props.created}
+                            updated={self.props.updated}
+                            ctr={self.props.ctr}
+                        />
+                    </div>
+                </div>
+            </div>
+        );
+    }
+})
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+export default ThumbnailModalChild;
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/js/components/core/Xylophone.js
+++ b/src/js/components/core/Xylophone.js
@@ -23,41 +23,36 @@ var Xylophone = React.createClass({
                 </div>
                 {
                     self.props.thumbnails.map(function(thumbnail, i) {
-                        if (thumbnail.type != 'random' && thumbnail.type !='centerframe') {
-                            var neonScoreData = UTILS.getNeonScoreData(thumbnail.neon_score),
-                                inlineStyle = {'height': neonScoreData.neonScore + '%'}
-                            ;
-                            var rating;
-                            // 0 - 59 : red
-                            // 60 - 84 : yellow
-                            // 85 - 99 : green
-                            if (neonScoreData.neonScore < 60) {
-                                rating = 'bad';
-                            }
-                            else if (neonScoreData.neonScore < 85) {
-                                rating = 'ok';
-                            }
-                            else {
-                                rating = 'good';
-                            }
-                            var className = 'wonderland-xylophone__bar is-' + rating + (thumbnail.enabled ? '' : ' is-disabled');
-                            return (
-                                <div
-                                    className="wonderland-xylophone__slot"
-                                    key={thumbnail.thumbnail_id}
-                                >
-                                    <div
-                                        style={inlineStyle}
-                                        className={className}
-                                        title={'Neonscore of ' + neonScoreData.neonScore}
-                                    >
-                                    </div>
-                                </div>
-                            );
+                        var neonScoreData = UTILS.getNeonScoreData(thumbnail.neon_score),
+                            inlineStyle = {'height': neonScoreData.neonScore + '%'}
+                        ;
+                        var rating;
+                        // 0 - 59 : red
+                        // 60 - 84 : yellow
+                        // 85 - 99 : green
+                        if (neonScoreData.neonScore < 60) {
+                            rating = 'bad';
+                        }
+                        else if (neonScoreData.neonScore < 85) {
+                            rating = 'ok';
                         }
                         else {
-                            return false;
+                            rating = 'good';
                         }
+                        var className = 'wonderland-xylophone__bar is-' + rating + (thumbnail.enabled ? '' : ' is-disabled');
+                        return (
+                            <div
+                                className="wonderland-xylophone__slot"
+                                key={thumbnail.thumbnail_id}
+                            >
+                                <div
+                                    style={inlineStyle}
+                                    className={className}
+                                    title={'Neonscore of ' + neonScoreData.neonScore}
+                                >
+                                </div>
+                            </div>
+                        );
                     })
                 }
             </div>

--- a/src/js/components/forms/AnalyzeVideoForm.js
+++ b/src/js/components/forms/AnalyzeVideoForm.js
@@ -33,7 +33,8 @@ var AnalyzeVideoForm = React.createClass({
             accessToken: '',
             refreshToken: '',
             mode: 'silent', // loading/disabled/silent/error
-            url: '',
+            videoUrl: '',
+            optionalDefaultThumbnailUrl: '',
             optionalTitle: '',
             maxVideoCount: 10,
             currentVideoCount: self.props.videoCountServed
@@ -84,7 +85,7 @@ var AnalyzeVideoForm = React.createClass({
                 buttonClassName = 'button is-medium is-primary is-disabled';
                 inputClassName = 'input is-medium is-disabled';
             }
-            else if (!self.state.url && self.state.mode === 'silent') {
+            else if (!self.state.videoUrl && self.state.mode === 'silent') {
                 buttonClassName = 'button is-medium is-primary is-disabled';
                 inputClassName = 'input is-medium';
             }
@@ -102,10 +103,10 @@ var AnalyzeVideoForm = React.createClass({
                                 required
                                 className={inputClassName}
                                 type="url"
-                                ref="url"
-                                onChange={self.handleChangeUrl}
-                                value={self.state.url}
-                                placeholder={T.get('analyze.videoUrl')}
+                                ref="videoUrl"
+                                onChange={self.handleChangeVideoUrl}
+                                value={self.state.videoUrl}
+                                placeholder={T.get('analyzeVideo.videoUrl')}
                             />
                         </p>
                         <p className="control">
@@ -115,7 +116,17 @@ var AnalyzeVideoForm = React.createClass({
                                 ref="optionalTitle"
                                 onChange={self.handleChangeOptionalTitle}
                                 value={self.state.optionalTitle}
-                                placeholder={T.get('analyze.optionalTitle')}
+                                placeholder={T.get('analyzeVideo.optionalTitle')}
+                            />
+                        </p>
+                        <p className="control">
+                            <input
+                                className={inputClassName}
+                                type="url"
+                                ref="optionalDefaultThumbnailUrl"
+                                onChange={self.handleChangeOptionalDefaultThumbnailUrl}
+                                value={self.state.optionalDefaultThumbnailUrl}
+                                placeholder={T.get('analyzeVideo.optionalDefaultThumbnailUrl')}
                             />
                         </p>
                         <p className="has-text-centered">
@@ -129,10 +140,10 @@ var AnalyzeVideoForm = React.createClass({
         }
 
     },
-    handleChangeUrl: function(e) {
+    handleChangeVideoUrl: function(e) {
         var self = this;
         self.setState({
-            url: e.target.value
+            videoUrl: e.target.value
         });
     },
     handleChangeOptionalTitle: function(e) {
@@ -141,39 +152,48 @@ var AnalyzeVideoForm = React.createClass({
             optionalTitle: e.target.value
         });
     },
+    handleChangeOptionalDefaultThumbnailUrl: function(e) {
+        var self = this;
+        self.setState({
+            optionalDefaultThumbnailUrl: e.target.value
+        });
+    },
     resetForm: function() {
         var self = this;
         self.setState({
-            url: '',
+            mode: 'silent',
+            videoUrl: '',
             optionalTitle: '',
-            mode: 'silent'
+            optionalDefaultThumbnailUrl: ''
         });
     },
     handleSubmit: function (e) {
         var self = this,
-            url = this.refs.url.value.trim(),
-            optionalTitle = self.refs.optionalTitle.value.trim() || UTILS.makeTitle()
+            videoUrl = this.refs.videoUrl.value.trim(),
+            optionalTitle = self.refs.optionalTitle.value.trim() || UTILS.makeTitle(),
+            optionalDefaultThumbnailUrl = self.refs.optionalDefaultThumbnailUrl.value.trim()
         ;
         e.preventDefault();
-        TRACKING.sendEvent(self, arguments, url);
+        TRACKING.sendEvent(self, arguments, videoUrl);
         self.setState({
-            mode: 'loading'
-        },
-            self.analyzeVideo(UTILS.dropboxUrlFilter(url), optionalTitle)
+                mode: 'loading'
+            }, self.analyzeVideo(videoUrl, optionalTitle, optionalDefaultThumbnailUrl)
         );
-        
     },
-    analyzeVideo: function (url, optionalTitle) {
+    analyzeVideo: function (videoUrl, optionalTitle, optionalDefaultThumbnailUrl) {
         var self = this,
             videoId = UTILS.generateId(),
             options = {
                 data: {
                     external_video_ref: videoId,
-                    url: UTILS.properEncodeURI(url),
+                    url: UTILS.properEncodeURI(UTILS.dropboxUrlFilter(videoUrl)),
                     title: optionalTitle
                 }
             }
         ;
+        if (optionalDefaultThumbnailUrl) {
+            options['default_thumbnail_url'] = UTILS.properEncodeURI(optionalDefaultThumbnailUrl);
+        }
         AJAX.doPost('videos', options)
             .then(function(json) {
                 self.setState({
@@ -188,19 +208,25 @@ var AnalyzeVideoForm = React.createClass({
                 }
             })
             .catch(function(err) {
-                if (err.status === 402) {
-                    E.checkForError(T.get('copy.analyzeVideo.maxLimitHit', {
-                        '%limit': self.state.maxVideoCount,
-                        '@link': UTILS.CONTACT_EXTERNAL_URL
-                    }), false);
-                }
-                else {
-                    E.checkForError(err.statusText, false);
+                switch (err.status) {
+                    case 402:
+                        E.checkForError(T.get('copy.analyzeVideo.maxLimitHit', {
+                            '%limit': self.state.maxVideoCount,
+                            '@link': UTILS.CONTACT_EXTERNAL_URL
+                        }), false);
+                        break;
+                    case 400:
+                        E.checkForError(T.get('copy.analyzeVideo.badRequest'), false);
+                        break;
+                    default:
+                        E.checkForError(JSON.parse(err.responseText).error.data, false);
+                        break;
                 }
                 self.setState({
                     mode: 'error'
                 });
-            });
+            })
+        ;
     }
 });
 

--- a/src/js/components/forms/IntegrationsForm.js
+++ b/src/js/components/forms/IntegrationsForm.js
@@ -120,7 +120,7 @@ var IntegrationsForm = React.createClass({
                                     <li>Log into your Brightcove account</li>
                                     <li>Your Publisher ID is below where it says “Welcome, _name_”
                                         <br/>
-                                        <img src="/img/brightcove_publisher_id.png"/>
+                                        <img src="/img/brightcove_publisher_id.png" />
                                     </li>
                                 </ol>
                             </div>
@@ -138,11 +138,11 @@ var IntegrationsForm = React.createClass({
                                     <li>Click on “Account Settings” in the top right corner of the page</li>
                                     <li>Select "API Management" in the left sidebar
                                         <br/>
-                                        <img src="/img/brightcove_account_settings.png"/>
+                                        <img src="/img/brightcove_account_settings.png" />
                                     </li>
                                     <li>In the list of tokens, you should see at least one Read Token with "URL Access" listed in the options. You can copy this token by clicking the middle "Copy" button in the "Manage" column.
                                         <br/>
-                                        <img src="/img/brightcove_read_token.png"/>
+                                        <img src="/img/brightcove_read_token.png" />
                                     </li>
                                 </ol>
                                 Note: You may have multiple Read Tokens with URL Access if you or someone on your team has engaged in API management tasks in the past. You can use any Read Token as long as the one you pick has URL Access.
@@ -161,11 +161,11 @@ var IntegrationsForm = React.createClass({
                                     <li>Click on “Account Settings” in the top right corner of the page</li>
                                     <li>Select "API Management" in the left sidebar
                                         <br/>
-                                        <img src="/img/brightcove_account_settings.png"/>
+                                        <img src="/img/brightcove_account_settings.png" />
                                     </li>
                                     <li>In the bottom right of the tokens panel, click the dropdown menu and select “Write Token” to create a new token.
                                         <br/>
-                                        <img src="/img/brightcove_write_token.png"/>
+                                        <img src="/img/brightcove_write_token.png" />
                                     </li>
                                     <li>The new Write Token should appear at the bottom of the list. You can copy this token by clicking the middle "Copy" button under the "Manage" column.</li>
                                 </ol>

--- a/src/js/components/wonderland/ThumbBox.js
+++ b/src/js/components/wonderland/ThumbBox.js
@@ -26,21 +26,9 @@ var ThumbBox = React.createClass({
             toggleModalButton = '',
             enabledIndicator = UTILS.enabledDisabledIcon(!self.props.isEnabled), // we want the opposite
             enabledTooltip = self.props.isServingEnabled ? (!self.props.isEnabled ? 'Enable this Thumbnail' : 'Disable this Thumbnail') : 'Serving is Disabled for this Account',
-            enabledDisabledClass = self.props.isServingEnabled ? '' : ' -disabled'
+            enabledDisabledClass = self.props.isServingEnabled ? '' : ' -disabled',
+            modalClass = self.props.handleToggleModal ? '' : ' -disabled'
         ;
-        if (self.props.handleToggleModal) {
-            toggleModalButton = function() {
-                return (
-                    <span
-                        className="icon wonderland-thumbbox__tool"
-                        onClick={self.props.handleToggleModal}
-                        title="View this Thumbnail larger"
-                    >
-                        <i className="fa fa-search-plus" aria-hidden="true"></i>
-                    </span>
-                );
-            }();
-        }
         return (
             <aside className="wonderland-thumbbox">
                 <div className="wonderland-thumbbox__tools">
@@ -68,7 +56,13 @@ var ThumbBox = React.createClass({
                     >
                         <i className="fa fa-download" aria-hidden="true"></i>
                     </a>
-                    {toggleModalButton}
+                    <span
+                        className={'icon wonderland-thumbbox__tool' + modalClass}
+                        onClick={self.props.handleToggleModal}
+                        title="View this Thumbnail larger"
+                    >
+                        <i className="fa fa-search-plus" aria-hidden="true"></i>
+                    </span>
                 </div>
                 <span className="wonderland-thumbbox__tease" title="Expand">
                     <i className="fa fa-caret-right" aria-hidden="true"></i>

--- a/src/js/components/wonderland/Thumbnail.js
+++ b/src/js/components/wonderland/Thumbnail.js
@@ -7,7 +7,7 @@ import React from 'react';
 
 import AJAX from '../../modules/ajax';
 import ModalParent from '../core/ModalParent';
-import ImageModalChild from '../core/ImageModalChild';
+import ThumbnailModalChild from '../core/ThumbnailModalChild';
 import ThumbBox from '../wonderland/ThumbBox';
 import UTILS from '../../modules/utils';
 import T from '../../modules/translation';
@@ -18,7 +18,6 @@ var Thumbnail = React.createClass({
 	// mixins: [ReactDebugMixin],
     propTypes: {
         isEnabled: React.PropTypes.bool.isRequired,
-        videoStateMapping: React.PropTypes.string.isRequired,
         index: React.PropTypes.number.isRequired,
         rawNeonScore: React.PropTypes.oneOfType([React.PropTypes.number, React.PropTypes.string]),
         cookedNeonScore: React.PropTypes.oneOfType([React.PropTypes.number, React.PropTypes.string]).isRequired,
@@ -33,7 +32,7 @@ var Thumbnail = React.createClass({
         thumbnailId: React.PropTypes.string.isRequired,
         created: React.PropTypes.string.isRequired,
         updated: React.PropTypes.string.isRequired,
-        ctr: React.PropTypes.oneOfType([React.PropTypes.number, React.PropTypes.string]),
+        ctr: React.PropTypes.oneOfType([React.PropTypes.number, React.PropTypes.string])
     },
     getInitialState: function () {
         var self = this;
@@ -64,14 +63,14 @@ var Thumbnail = React.createClass({
     },
     render: function() {
         var self = this,
-            additionalClass = 'tag is-' + (self.state.isEnabled ? self.props.videoStateMapping : 'disabled') + ' is-medium wonderland-thumbnail__score',
+            additionalClass = 'tag is-medium wonderland-thumbnail__score' + (self.state.isEnabled ? ' is-primary' : ' is-disabled'),
             caption = 'Thumbnail ' + (self.props.index + 1),
             enabledDisabled = self.state.isBusy ? 'disabled' : '',
             src = (self.props.forceOpen ? self.props.strippedUrl : '/img/clear.gif'),
             dataSrc = (self.props.forceOpen ? '' : self.props.strippedUrl),
             figureClassName = 'wonderland-thumbnail ' + (self.state.isEnabled ? 'is-wonderland-enabled' : 'is-wonderland-disabled'),
             enabledIndicator = UTILS.enabledDisabledIcon(self.state.isEnabled), // we want the opposite
-            neonScore = UTILS.NEON_SCORE_ENABLED ? <span className={additionalClass} title={T.get('neonScore')}>{self.props.cookedNeonScore}</span> : '',
+            neonScore = (UTILS.NEON_SCORE_ENABLED && self.props.type === 'neon') ? <span className={additionalClass} title={T.get('neonScore')}>{self.props.cookedNeonScore}</span> : '',
             handleEnabledChangeHook = self.props.isServingEnabled ? self.handleEnabledChange : function() { return false; }
         ;
         return (
@@ -94,8 +93,19 @@ var Thumbnail = React.createClass({
                 />
                 <figcaption className="wonderland-thumbnail__caption">
                     {neonScore}
-                    <input className="wonderland-thumbnail__enabled" onChange={handleEnabledChangeHook} checked={self.state.isEnabled} type="checkbox" disabled={enabledDisabled} />
-                    <span onClick={self.handleToggleModal} className="wonderland-thumbnail__indicator -foreground"><i className={'fa fa-' + enabledIndicator}></i></span>
+                    <input
+                        className="wonderland-thumbnail__enabled"
+                        onChange={handleEnabledChangeHook}
+                        checked={self.state.isEnabled}
+                        type="checkbox"
+                        disabled={enabledDisabled}
+                    />
+                    <span
+                        onClick={self.handleToggleModal}
+                        className="wonderland-thumbnail__indicator -foreground"
+                    >
+                        <i className={'fa fa-' + enabledIndicator}></i>
+                    </span>
                     <ThumbBox
                         copyUrl={self.props.url}
                         downloadUrl={self.props.url}
@@ -103,15 +113,15 @@ var Thumbnail = React.createClass({
                         handleToggleModal={self.handleToggleModal}
                         handleEnabledChange={handleEnabledChangeHook}
                         isServingEnabled={self.props.isServingEnabled}
+                        type={self.props.type}
                     />
                 </figcaption>
                 <ModalParent
                     isModalActive={self.state.isModalActive}
                     handleToggleModal={self.handleToggleModal}
-                    isModalContentClipped={true}
                     isModalContentMax={true}
                 >
-                    <ImageModalChild
+                    <ThumbnailModalChild
                         caption={caption}
                         strippedUrl={self.props.strippedUrl}
                         copyUrl={self.props.url}

--- a/src/js/components/wonderland/ThumbnailInfoBox.js
+++ b/src/js/components/wonderland/ThumbnailInfoBox.js
@@ -17,8 +17,8 @@ var ThumbnailInfoBox = React.createClass({
         return (
             <aside className="box">
                 <dl className="wonderland-dl">
-                    <dt className="wonderland-dt">Frame No.</dt>
-                        <dd className="wonderland-dd">{self.props.frameNo}</dd>
+                    <dt className={'wonderland-dt' + (self.props.frameNo > 0 ? '' : ' is-hidden')}>Frame No.</dt>
+                        <dd className={'wonderland-dd' + (self.props.frameNo > 0 ? '' : ' is-hidden')}>{self.props.frameNo}</dd>
                     <dt className="wonderland-dt">Type</dt>
                         <dd className="wonderland-dd">{self.props.type}</dd>
                     <dt className="wonderland-dt">Dimensions</dt>

--- a/src/js/components/wonderland/Thumbnails.js
+++ b/src/js/components/wonderland/Thumbnails.js
@@ -16,7 +16,6 @@ var Thumbnails = React.createClass({
 	// mixins: [ReactDebugMixin],
     propTypes: {
         videoState: React.PropTypes.string.isRequired,
-        videoStateMapping: React.PropTypes.string.isRequired,
         thumbnails: React.PropTypes.array.isRequired,
         forceOpen: React.PropTypes.bool.isRequired,
         isServingEnabled: React.PropTypes.bool.isRequired
@@ -26,10 +25,10 @@ var Thumbnails = React.createClass({
         if (self.props.videoState === 'processing') {
             return (
                 <div className="wonderland-slides container">
-                    <Slide slideContent={T.get('copy.processingSlide.1')} icon="check-circle"/>
-                    <Slide slideContent={T.get('copy.processingSlide.2')} icon="clock-o"/>
-                    <Slide slideContent={T.get('copy.processingSlide.3')} icon="trophy"/>
-                    <Slide slideContent={T.get('copy.processingSlide.4')} icon="picture-o"/>
+                    <Slide slideContent={T.get('copy.processingSlide.1')} icon="check-circle" />
+                    <Slide slideContent={T.get('copy.processingSlide.2')} icon="clock-o" />
+                    <Slide slideContent={T.get('copy.processingSlide.3')} icon="trophy" />
+                    <Slide slideContent={T.get('copy.processingSlide.4')} icon="picture-o" />
                 </div>
             );
         }
@@ -38,39 +37,34 @@ var Thumbnails = React.createClass({
                 <div className="columns is-multiline is-mobile">
                     {
                         self.props.thumbnails.map(function(thumbnail, i) {
-                            if (thumbnail.type != 'random' && thumbnail.type !='centerframe') {
-                                var neonScoreData = UTILS.NEON_SCORE_ENABLED ? UTILS.getNeonScoreData(thumbnail.neon_score) : '',
-                                    rawNeonScore = UTILS.NEON_SCORE_ENABLED ? thumbnail.neon_score : 0,
-                                    cookedNeonScore = UTILS.NEON_SCORE_ENABLED ? neonScoreData.neonScore : 0,
-                                    strippedUrl = UTILS.stripProtocol(thumbnail.url)
-                                ;
-                                return (
-                                    <div className="column is-half-mobile is-one-third-tablet is-one-third-desktop" key={thumbnail.thumbnail_id}>
-                                        <Thumbnail
-                                            index={i}
-                                            videoStateMapping={self.props.videoStateMapping}
-                                            isEnabled={thumbnail.enabled}
-                                            strippedUrl={strippedUrl}
-                                            url={thumbnail.url}
-                                            rawNeonScore={rawNeonScore}
-                                            cookedNeonScore={cookedNeonScore}
-                                            frameNo={thumbnail.frameno}
-                                            type={thumbnail.type}
-                                            forceOpen={self.props.forceOpen}
-                                            isServingEnabled={self.props.isServingEnabled}
-                                            width={thumbnail.width}
-                                            height={thumbnail.height}
-                                            thumbnailId={thumbnail.thumbnail_id}
-                                            created={thumbnail.created}
-                                            updated={thumbnail.updated}
-                                            ctr={thumbnail.ctr}
-                                        />
-                                    </div>
-                                );
-                            }
-                            else {
-                                return false;
-                            }
+                            var neonScoreData = UTILS.NEON_SCORE_ENABLED ? UTILS.getNeonScoreData(thumbnail.neon_score) : '',
+                                rawNeonScore = UTILS.NEON_SCORE_ENABLED ? thumbnail.neon_score : 0,
+                                cookedNeonScore = UTILS.NEON_SCORE_ENABLED ? neonScoreData.neonScore : 0,
+                                strippedUrl = UTILS.stripProtocol(thumbnail.url),
+                                frameNo = thumbnail.frameno || 0
+                            ;
+                            return (
+                                <div className="column is-half-mobile is-half-tablet is-one-third-desktop" key={thumbnail.thumbnail_id}>
+                                    <Thumbnail
+                                        index={i}
+                                        isEnabled={thumbnail.enabled}
+                                        strippedUrl={strippedUrl}
+                                        url={thumbnail.url}
+                                        rawNeonScore={rawNeonScore}
+                                        cookedNeonScore={cookedNeonScore}
+                                        frameNo={frameNo}
+                                        type={thumbnail.type}
+                                        forceOpen={self.props.forceOpen}
+                                        isServingEnabled={self.props.isServingEnabled}
+                                        width={thumbnail.width}
+                                        height={thumbnail.height}
+                                        thumbnailId={thumbnail.thumbnail_id}
+                                        created={thumbnail.created}
+                                        updated={thumbnail.updated}
+                                        ctr={thumbnail.ctr}
+                                    />
+                                </div>
+                            );
                         })
                     }
                 </div>

--- a/src/js/components/wonderland/Video.js
+++ b/src/js/components/wonderland/Video.js
@@ -30,6 +30,46 @@ var Video = React.createClass({
             created: '',
         }
     },
+    fixThumbnails: function(rawThumbnails) {
+        var defaults = [],
+            customs = [],
+            neons = [],
+            nonNeons = []
+        ;
+        // Pass 1 - sort into `default`, `custom` and `neon`
+        rawThumbnails.map(function(rawThumbnail, i) {
+            switch (rawThumbnail.type) {
+                case 'neon':                    
+                    neons.push(rawThumbnail);
+                    break;
+                case 'custom':
+                    customs.push(rawThumbnail);
+                    break;
+                case 'default':
+                    defaults.push(rawThumbnail);
+                    break;
+                default:
+                    // WE DON'T CARE. OK WE DO. BUT NOT ENOUGH TO DO ANYTHING.
+                    break;
+            }
+        });
+        // Pass 2 - sort `custom` by rank ASC
+        customs.sort(function(a, b) {
+            return a.rank - b.rank;
+        });
+        // Pass 3 - sort `neon` by neon_score DESC
+        neons.sort(function(a, b) {
+            return (b.neon_score === '?' ? 0 : b.neon_score) - (a.neon_score === '?' ? 0 : a.neon_score);
+        });
+        // Pass 4 - assemble the output
+        nonNeons = customs.concat(defaults);
+        if (nonNeons.length > 0) {
+            return neons.concat(nonNeons[0]);
+        }
+        else {
+            return neons;
+        }
+    },
     getInitialState: function() {
         var self = this;
         return {
@@ -38,9 +78,7 @@ var Video = React.createClass({
             videoStateMapping: UTILS.VIDEO_STATE[self.props.videoState].mapping,
             forceOpen: self.props.forceOpen,
             thumbnails: self.props.thumbnails,
-            sortedThumbnails: self.props.thumbnails.sort(function(a, b) {
-                return (b.neon_score === '?' ? 0 : b.neon_score) - (a.neon_score === '?' ? 0 : a.neon_score);
-            }),
+            sortedThumbnails: self.fixThumbnails(self.props.thumbnails),
             title: self.props.title,
             error: self.props.error,
             created: self.props.created,
@@ -108,7 +146,6 @@ var Video = React.createClass({
                     <VideoMain
                         forceOpen={self.state.forceOpen}
                         messageNeeded={messageNeeded}
-                        videoStateMapping={self.state.videoStateMapping}
                         thumbnails={self.state.sortedThumbnails}
                         videoState={self.state.videoState}
                         videoLink={videoLink}
@@ -157,9 +194,7 @@ var Video = React.createClass({
                         self.setState({
                             status: 200,
                             thumbnails: video.thumbnails,
-                            sortedThumbnails: video.thumbnails.sort(function(a, b) {
-                                return (b.neon_score === '?' ? 0 : b.neon_score) - (a.neon_score === '?' ? 0 : a.neon_score);
-                            }),
+                            sortedThumbnails: self.fixThumbnails(video.thumbnails),
                             videoState: video.state,
                             videoStateMapping: UTILS.VIDEO_STATE[video.state].mapping,
                             title: video.title,

--- a/src/js/components/wonderland/VideoMain.js
+++ b/src/js/components/wonderland/VideoMain.js
@@ -12,7 +12,6 @@ var VideoMain = React.createClass({
     propTypes: {
         forceOpen: React.PropTypes.bool.isRequired,
         messageNeeded: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.object]).isRequired,
-        videoStateMapping: React.PropTypes.string.isRequired,
         thumbnails: React.PropTypes.array.isRequired,
         videoState: React.PropTypes.string.isRequired,
         videoLink: React.PropTypes.string.isRequired,
@@ -29,17 +28,16 @@ var VideoMain = React.createClass({
             <div className={additionalClass}>
                 <br />
                 <div className="columns is-desktop">
-                    <div className="column is-10">
+                    <div className="column is-12-mobile is-10-desktop">
                         {self.props.messageNeeded}
                         <Thumbnails
-                            videoStateMapping={self.props.videoStateMapping}
                             thumbnails={self.props.thumbnails}
                             videoState={self.props.videoState}
                             forceOpen={self.props.forceOpen}
                             isServingEnabled={self.props.isServingEnabled}
                         />
                     </div>
-                    <aside className="column is-2">
+                    <aside className="column is-12-mobile is-2-desktop">
                         <VideoInfoBox
                             videoLink={self.props.videoLink}
                             duration={self.props.duration}

--- a/src/js/mixins/Account.js
+++ b/src/js/mixins/Account.js
@@ -54,7 +54,7 @@ var Account = {
             })
             .catch(function(err) {
                 var self = this;
-                console.log(err);
+                console.log(JSON.parse(err.responseText).error.data, false);
                 self.setState({
                     isLoading: false,
                     isError: true

--- a/src/js/modules/translation.js
+++ b/src/js/modules/translation.js
@@ -58,6 +58,7 @@ const _DEFAULT_LOCALE = 'en-US',
             'copy.analyzeVideo.heading': 'Analyze Video',
             'copy.analyzeVideo.body': '',
             'copy.analyzeVideo.maxLimitHit': 'Whoops! You have hit your demo limit of %limit. Please <a href="@link">contact us</a> to buy more.',
+            'copy.analyzeVideo.badRequest': 'Please check your Video URL or your Thumbnail URL as they may be unreachable or badly formed.',
 
             'copy.terms.title': 'Terms of Service',
             'copy.terms.heading': 'Terms of Service',
@@ -143,8 +144,9 @@ const _DEFAULT_LOCALE = 'en-US',
             'reset.sendReset': 'Send Reset Instructions',
             'reset.message': 'Please Check your Email for Reset Instructions',
             //analyze page
-            'analyze.videoUrl': 'Video URL',
-            'analyze.optionalTitle': 'Optional Title',
+            'analyzeVideo.videoUrl': 'Video URL',
+            'analyzeVideo.optionalTitle': 'Optional Title',
+            'analyzeVideo.optionalDefaultThumbnailUrl': 'Optional Default Thumbnail URL',
             //navigation bar
 
             'nav.home': 'Home',


### PR DESCRIPTION
- created and using new truncate mixin - `x-truncate`
- `ImageModalChild` to `ThumbnailModalChild`, filename and all references
- `isModalContentClipped` no longer required, defaults to `false`
- changed thumbnail iteration to no longer exclude `centerframe` and `random`, done as part of new `` function
- changed `url` references to `videoUrl` to limit confusion
- `handleChangeUrl` -> `handleChangeVideoUrl`
- expanded the `AnalyzeVideoForm` to have an (optional) Default / Optional Thumbnail URL field
- better error handling in `AnalyzeVideoForm` to catch `400` and `402`
- added new translation string for error and updated `analyze` -> `analyzeVideo`
- `"/>` to `" />`
- refactor of `toggleModalButton` code to be more consistent with rest of component
- removed `videoStateMapping` prop which is passed all the way through to make the neonScore a specific colour. No longer needed.
- only show neonScore if its a `neon` thumbnail
- some formatting of long attributed HTML elements
- deal with no Frame No (like you get on an uploaded default), don't show info
- new `fixThumbnails` function to take thumbs returned from back end, sort, get rid of unwanted and structure in correct way. This replaces previous `.sort` functionality
- layout tweak to `VideoMain` component, i.e. how `Thumbnails` and `VideoInfobox` are rendered
- better error message in `Account`
- turned on NeonScore for now
