### PR TITLE
Make Modal Box Smarter #988

### DIFF
--- a/src/css/components/_modal.scss
+++ b/src/css/components/_modal.scss
@@ -1,11 +1,19 @@
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
-.wonderland-modal {
-}
-
 .wonderland-modal-content {
     &.is-clipped {
         overflow: hidden;
+    }
+    &.is-max {
+        @media screen and (min-width: $tablet) {
+            width: 90%;
+        }
+        @media screen and (min-width: $desktop) {
+            // empty
+        }
+        @media screen and (min-width: $widescreen) {
+            width: $widescreen * 0.9;
+        }
     }
 }
 

--- a/src/js/components/core/ModalParent.js
+++ b/src/js/components/core/ModalParent.js
@@ -7,16 +7,20 @@ import ReactDebugMixin from 'react-debug-mixin';
 
 var ModalParent = React.createClass({
 	mixins: [ReactDebugMixin],
+    propTypes: {
+        isModalActive: React.PropTypes.bool.isRequired,
+        isModalContentClipped: React.PropTypes.bool.isRequired,
+        handleToggleModal: React.PropTypes.func.isRequired,
+        isModalContentMax: React.PropTypes.bool
+    },
+    getDefaultProps: function() {
+        return {
+            isModalContentMax: false
+        }
+    },
     handleToggleModal: function(e) {
         var self = this;
         self.props.handleToggleModal();
-    },
-    handleEscKey:function(e) {
-        var self = this;
-        if (e.keyCode === 27 && self.props.isModalActive) {
-            e.preventDefault();
-            self.handleToggleModal(e);
-        }
     },
     componentWillMount:function() {
         var self = this;
@@ -29,7 +33,7 @@ var ModalParent = React.createClass({
     render: function() {
         var self = this,
             modalClass = self.props.isModalActive ? ' is-active' : '',
-            modalContentClass = self.props.isModalContentClipped ? ' is-clipped' : ''
+            modalContentClass = (self.props.isModalContentClipped ? ' is-clipped' : '') + (self.props.isModalContentMax ? ' is-max' : '')
         ;
         return (
             <div className={'wonderland-modal modal' + modalClass}>
@@ -40,7 +44,14 @@ var ModalParent = React.createClass({
                 <button className="wonderland-modal-close modal-close" onClick={self.handleToggleModal}></button>
             </div>
         );
-    }
+    },
+    handleEscKey:function(e) {
+        var self = this;
+        if (e.keyCode === 27 && self.props.isModalActive) { // 27 = Escape
+            e.preventDefault();
+            self.handleToggleModal(e);
+        }
+    },
 })
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/js/components/wonderland/Thumbnail.js
+++ b/src/js/components/wonderland/Thumbnail.js
@@ -109,6 +109,7 @@ var Thumbnail = React.createClass({
                     isModalActive={self.state.isModalActive}
                     handleToggleModal={self.handleToggleModal}
                     isModalContentClipped={true}
+                    isModalContentMax={true}
                 >
                     <ImageModalChild
                         caption={caption}


### PR DESCRIPTION
- introduce new `is-max` property for `ModalParent` so we can force the
  default (Bulma) modal to be wider (it only kicks in on `$Desktop` and
  bigger)
- `ModalParent` was missing `propTypes`, added these and made sure
  `isModalContentMax` defaults to `false` so as not to break existing
  usage
