### PR TITLE
Click on VideoHeader needs to be all encompassing #996

### DIFF
--- a/src/js/components/wonderland/Video.js
+++ b/src/js/components/wonderland/Video.js
@@ -122,7 +122,9 @@ var Video = React.createClass({
         }
     },
     handleVideoOpenToggle: function(e) {
-        e.preventDefault();
+        if (e.target.type === 'text') { // hack
+            return false;
+        }
         var self = this;
         self.setState({
             forceOpen: !self.state.forceOpen

--- a/src/js/components/wonderland/VideoHeader.js
+++ b/src/js/components/wonderland/VideoHeader.js
@@ -24,12 +24,12 @@ var VideoHeader = React.createClass({
     render: function() {
         var self = this,
             toggleButtonContent = self.props.forceOpen ? <i className="fa fa-chevron-up" aria-hidden="true"></i> : <i className="fa fa-chevron-down" aria-hidden="true"></i>,
-            toggleButton = <a className="button is-medium" onClick={self.props.handleVideoOpenToggle}>{toggleButtonContent}</a>,
+            toggleButton = <a className="button is-medium">{toggleButtonContent}</a>,
             videoTranslatedState = T.get('copy.' + self.props.videoState + 'State'),
             xylophone = UTILS.NEON_SCORE_ENABLED ? <Xylophone thumbnails={self.props.thumbnails} /> : ''
         ;
         return (
-            <nav className="wonderland-video__header navbar is-marginless">
+            <nav className="wonderland-video__header navbar is-marginless" onClick={self.props.handleVideoOpenToggle}>
                 <div className="navbar-left">
                     <div className="navbar-item">
                         <a className={self.props.additionalClass} title={self.props.videoState}>


### PR DESCRIPTION
- moved click back to nav element
- added check in `handleVideoOpenToggle` to make sure we didn’t click a
  text element
