### PR TITLE
Edge cases for Video Results #1033

### DIFF
--- a/src/js/components/core/NavigationBar.js
+++ b/src/js/components/core/NavigationBar.js
@@ -10,6 +10,7 @@ var NavigationBar = React.createClass({
 	// mixins: [ReactDebugMixin],
     propTypes: {
         isLoading: React.PropTypes.bool.isRequired,
+        alertMessage: React.PropTypes.oneOfType([React.PropTypes.element, React.PropTypes.string]),
         // These 2 props hold the API call to make to go to the Previous and
         // Next page
         prevPageAPICall: React.PropTypes.string.isRequired,
@@ -37,46 +38,59 @@ var NavigationBar = React.createClass({
     },
     render() {
         var self = this,
+            // Its quite simple here:
+            // - if we are loading, Prev and Next are disabled
+            // - if we are on page 1, Prev is disabled
+            // - if we don't have a Prev API Call, Prev is disabled
+            // - if we don't have a Next API Call, Next is disabled
+            // - if we bring back, less videos than we requested, we know we have run out, so Next is disabled
             prevDisabledAttribute = self.props.isLoading || (self.props.prevPageAPICall === '') || (self.props.currentPage === 1),
             nextDisabledAttribute = self.props.isLoading || (self.props.nextPageAPICall === '') || (self.props.videoCountServed < self.props.videoCountRequested),
             loadingClass = 'button is-primary is-medium' + (self.props.isLoading ? ' is-loading' : '')
         ;
+        // Edge Case - when we first hit the site, Virgin Mode
+        if ((self.props.prevPageAPICall === '') && (self.props.nextPageAPICall === '') && (self.props.currentPage === 1)) {
+            return false;
+        }
         return (
-            <nav className="navbar">
-                <div className="navbar-left">
-                    <div className="navbar-item">
-                        <button
-                            ref="prevButton"
-                            data-loc={self.props.prevPageAPICall}
-                            disabled={prevDisabledAttribute}
-                            className={loadingClass}
-                            onClick={self.handlePrevButton}
-                            title={T.get('action.previous')}
-                        >
-                            <i className="fa fa-chevron-circle-left" aria-hidden="true"></i>
-                            &nbsp;{T.get('action.previous')}
-                        </button>
+            <div>
+                {self.props.alertMessage}
+                <nav className="navbar">
+                    <div className="navbar-left">
+                        <div className="navbar-item">
+                            <button
+                                ref="prevButton"
+                                data-loc={self.props.prevPageAPICall}
+                                disabled={prevDisabledAttribute}
+                                className={loadingClass}
+                                onClick={self.handlePrevButton}
+                                title={T.get('action.previous')}
+                            >
+                                <i className="fa fa-chevron-circle-left" aria-hidden="true"></i>
+                                &nbsp;{T.get('action.previous')}
+                            </button>
+                        </div>
                     </div>
-                </div>
-                <div className="navbar-item has-text-centered">
-                    <p className="subtitle is-5">Page {self.props.currentPage}</p>
-                </div>
-                <div className="navbar-right">
-                    <div className="navbar-item">
-                        <button
-                            ref="nextButton"
-                            data-loc={self.props.nextPageAPICall}
-                            disabled={nextDisabledAttribute}
-                            className={loadingClass}
-                            onClick={self.handleNextButton}
-                            title={T.get('action.next')}
-                        >
-                            {T.get('action.next')}&nbsp;
-                            <i className="fa fa-chevron-circle-right" aria-hidden="true"></i>
-                        </button>
+                    <div className="navbar-item has-text-centered">
+                        <p className="subtitle is-5">Page {self.props.currentPage}</p>
                     </div>
-                </div>
-            </nav>
+                    <div className="navbar-right">
+                        <div className="navbar-item">
+                            <button
+                                ref="nextButton"
+                                data-loc={self.props.nextPageAPICall}
+                                disabled={nextDisabledAttribute}
+                                className={loadingClass}
+                                onClick={self.handleNextButton}
+                                title={T.get('action.next')}
+                            >
+                                {T.get('action.next')}&nbsp;
+                                <i className="fa fa-chevron-circle-right" aria-hidden="true"></i>
+                            </button>
+                        </div>
+                    </div>
+                </nav>
+            </div>
         );
     },
     handleKeyEvent: function(e) {

--- a/src/js/components/wonderland/Videos.js
+++ b/src/js/components/wonderland/Videos.js
@@ -24,7 +24,8 @@ var Videos = React.createClass({
             videoCountServed: -1,
             currentPage: 0,
             isLoading: false,
-            bonusSearchUrl: '' // used to hold the next/prev choice
+            pseudoPageUrl: '?', // used to hold the Prev / Next choice
+            previousPseudoPageUrl: '' // used to hold the Page before
         }  
     },
     componentDidMount: function() {
@@ -44,8 +45,19 @@ var Videos = React.createClass({
                 'upload': T.get('copy.analyzeVideoPanel.panel.2'),
                 'th-large': T.get('copy.analyzeVideoPanel.panel.3')
             },
-            tutorialComponent = self.state.videoCountServed === 0 ? <section className="section"><TutorialPanels panels={panels}/></section> : ''
+            tutorialComponent = self.state.videoCountServed === 0 ? <section className="section"><TutorialPanels panels={panels}/></section> : '',
+            prevPageAPICall = '',
+            alertMessage = ''
         ;
+        // Edge Case - when we hit a Next page with 0 results, limbo
+        if ((self.state.prevPageAPICall === '') && (self.state.nextPageAPICall === '') && (self.state.currentPage > 1)) {
+            prevPageAPICall = self.state.previousPseudoPageUrl;
+            alertMessage = <Message header={[T.get('warning.noMoreVideosHeader')]} body={[T.get('warning.noMoreVideosBody')]} flavour="warning" />;
+        }
+        else {
+            prevPageAPICall = self.state.prevPageAPICall;
+            alertMessage = '';
+        }
         return (
             <div>
                 {tutorialComponent}
@@ -60,9 +72,10 @@ var Videos = React.createClass({
                         forceOpenFirstOverride={self.state.forceOpenFirstOverride}
                         videos={self.state.videos}
                         handleNewSearch={self.handleNewSearch}
-                        prevPageAPICall={self.state.prevPageAPICall}
+                        prevPageAPICall={prevPageAPICall}
                         nextPageAPICall={self.state.nextPageAPICall}
                         errorMessage={errorMessage}
+                        alertMessage={alertMessage}
                         currentPage={self.state.currentPage}
                         isLoading={self.state.isLoading}
                         videoCountServed={self.state.videoCountServed}
@@ -73,13 +86,14 @@ var Videos = React.createClass({
             </div>
         );
     },
-    handleNewSearch: function(bonusSearchUrl, pageAdjustment) {
+    handleNewSearch: function(pseudoPageUrl, pageAdjustment) {
         var self = this;
         if (!self._isMounted) {
             return false;
         }
         self.setState({
-            bonusSearchUrl: '?' + bonusSearchUrl.split('?')[1]
+            previousPseudoPageUrl: self.state.pseudoPageUrl,
+            pseudoPageUrl: pseudoPageUrl
         }, function() {
             self.doVideoSearch(pageAdjustment, false);
         });
@@ -98,14 +112,14 @@ var Videos = React.createClass({
             forceOpenFirstOverride: forceOpenFirstOverride == null ? true : false,
             currentPage: pageAdjustment ? (self.state.currentPage + pageAdjustment) : 1
         }, function() {
-            self.GET('videos/search' + self.state.bonusSearchUrl, options)
+            var _pseudoPageUrl = self.state.pseudoPageUrl ? self.state.pseudoPageUrl.split('?')[1] : '';
+            self.GET('videos/search?' + _pseudoPageUrl, options)
                 .then(function(json) {
                     if (!self._isMounted) {
                         return false;
                     }
                     self.setState({
                         videoCountServed: json.video_count,
-                        bonusSearchUrl: '',
                         isLoading: false
                     }, function() {
                         if (json.video_count === 0) {
@@ -114,7 +128,7 @@ var Videos = React.createClass({
                                 isError: false,
                                 videos: [],
                                 prevPageAPICall: '',
-                                nextPageAPICall: '',
+                                nextPageAPICall: ''
                             });
                         }
                         else {
@@ -123,7 +137,7 @@ var Videos = React.createClass({
                                 isError: false,
                                 videos: json.videos,
                                 prevPageAPICall: json.prev_page,
-                                nextPageAPICall: json.next_page,
+                                nextPageAPICall: json.next_page
                             });
                         }
                     });
@@ -140,7 +154,8 @@ var Videos = React.createClass({
                         prevPageAPICall: '',
                         nextPageAPICall: '',
                         videoCountServed: 0,
-                        bonusSearchUrl: '',
+                        pseudoPageUrl: '?',
+                        previousPseudoPageUrl: '',
                         isLoading: false
                     });
                 });

--- a/src/js/modules/translation.js
+++ b/src/js/modules/translation.js
@@ -189,7 +189,11 @@ const _DEFAULT_LOCALE = 'en-US',
             'nav.accountSettings': 'Account Settings',
             'nav.userSettings': 'User Settings',
 
-            //error messages
+            // Error messages
+
+            'warning.noMoreVideosHeader': 'Videos Warning',
+            'warning.noMoreVideosBody': 'There are no more Videos to show. Please go back using the Previous button below.',
+
             'error.passwordFormatInvalid': 'Passwords must be at least eight characters and include one number and one special character.',
             'error.passwordMatchInvalid': 'Password does not match the confirm password.',
             'error.unableToSignIn': 'Unable to Sign In',


### PR DESCRIPTION
- `bonusSearchUrl` to `pseudoPageUrl`
- added code for 2 x edge cases:
  - `previousPseudoPageUrl` is now used to hold the previous (good) page so that if we get the situation where 0 videos are returned (and its not the first page) we have a way back (e.g. 40 videos with a paging size of 10 gives us 4 good pages and a 5th page of 0) - with bonus error message, `alertMessage`
  - if we are on the first page and there are 0 videos (Virgin Mode) show no navigation
- trailing commas
- added translation for Warning message
