### PR TITLE
Self.GET errors on AJAX Video calls (Videos and Video page)

### DIFF
--- a/src/js/components/wonderland/Video.js
+++ b/src/js/components/wonderland/Video.js
@@ -15,7 +15,7 @@ import T from '../../modules/translation';
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
 var Video = React.createClass({
-    // mixins: [ReactDebugMixin],
+    mixins: [AjaxMixin], // ReactDebugMixin
     propTypes: {
         videoId: React.PropTypes.string.isRequired
     },


### PR DESCRIPTION
- `AjaxMixin` was imported but not referenced so there were `self.GET` errors
- related to #191 
