### PR TITLE
Avatar (Gravatar) basic support #1045

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "clipboard": "^1.5.10",
     "fnv-plus": "^1.2.12",
     "font-awesome": "^4.5.0",
+    "gravatar": "^1.5.2",
     "history": "1.12.5",
     "moment": "^2.12.0",
     "react": "^0.14.7",

--- a/src/css/components/_banner.scss
+++ b/src/css/components/_banner.scss
@@ -65,6 +65,15 @@ $smallest-ratio: 0.191;
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
+.wonderland-navbar__avatar {
+    margin: ($maximum-nav-height * $smallest-ratio) 0;
+    border-radius: 50%;
+    width: $maximum-nav-height * $smaller-ratio;
+    height: $maximum-nav-height * $smaller-ratio;
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
 .wonderland-navbar__icon {
     margin: ($maximum-nav-height * $smallest-ratio) 0;
     transition: color 0.3333s;

--- a/src/js/components/tabs/UserSettingsTab1.js
+++ b/src/js/components/tabs/UserSettingsTab1.js
@@ -6,6 +6,7 @@ import Message from '../wonderland/Message';
 import SESSION from '../../modules/session';
 import moment from 'moment';
 import T from '../../modules/translation';
+import gravatar from 'gravatar';
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
@@ -19,6 +20,7 @@ var UserSettingsTab1 = React.createClass({
             accessLevel: -1,
             created: '',
             updated: '',
+            avatar: ''
         }  
     },
     componentWillMount: function() {
@@ -30,7 +32,8 @@ var UserSettingsTab1 = React.createClass({
                     username: userData.username,
                     accessLevel: userData.access_level,
                     created: userData.created,
-                    updated: userData.updated
+                    updated: userData.updated,
+                    avatar: gravatar.url(userData.username, {s: '200', d: 'identicon'})
                 })
             })
             .catch(function(err) {
@@ -62,6 +65,10 @@ var UserSettingsTab1 = React.createClass({
                 <label className="label">{T.get('label.updated')}</label>
                 <p className={'control' + (self.state.isLoading ? ' is-disabled is-loading' : '')}>
                     <input className={'input'} type="text" value={updated} disabled />
+                </p>
+                <label className="label">{T.get('label.avatar')}</label>
+                <p className={'control' + (self.state.isLoading ? ' is-disabled is-loading' : '')}>
+                    <img src={self.state.avatar} alt={self.state.username} title={self.state.username} />
                 </p>
             </fieldset>
         )

--- a/src/js/components/wonderland/SiteBanner.js
+++ b/src/js/components/wonderland/SiteBanner.js
@@ -4,6 +4,7 @@ import React from 'react';
 // import ReactDebugMixin from 'react-debug-mixin';
 import SiteNavigation from '../wonderland/SiteNavigation';
 import SESSION from '../../modules/session';
+import gravatar from 'gravatar';
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -15,25 +16,26 @@ var SiteBanner = React.createClass({
         }
     },
     componentWillMount: function() {
-        var self = this;
+        var self = this,
+            displayName = '',
+            avatar = ''
+        ;
         if (SESSION.active()) {
             SESSION.user()
                 .then(function(userData) {
                     if (userData) {
+                        // https://en.gravatar.com/site/implement/images/
+                        avatar = gravatar.url(userData.username, {s: '60', d: 'identicon'});
                         if (userData.first_name) {
-                            if (self._isMounted) {
-                                self.setState({
-                                    displayName: userData.first_name
-                                });
-                            }
+                            displayName = userData.first_name;
                         }
                         else {
-                            if (self._isMounted) {
-                                self.setState({
-                                    displayName: userData.username
-                                });
-                            }
+                            displayName = userData.username
                         }
+                        self.setState({
+                            displayName: displayName,
+                            avatar: avatar
+                        });
                     }
                 })
                 .catch(function(err) {
@@ -45,14 +47,6 @@ var SiteBanner = React.createClass({
             // Do nothing
         }
     },
-    componentDidMount: function() {
-        var self = this;
-        self._isMounted = true;
-    },
-    componentWillUnmount: function() {
-        var self = this;
-        self._isMounted = false;
-    },
     render: function() {
         var self = this;
         return (
@@ -60,7 +54,7 @@ var SiteBanner = React.createClass({
                 <div className="container">
                     <nav className="navbar wonderland-navbar is-fullwidth">
                         <SiteNavigation side="left" isSignedIn={SESSION.active()} />
-                        <SiteNavigation displayName={self.state.displayName} side="right" isSignedIn={SESSION.active()} />
+                        <SiteNavigation avatar={self.state.avatar} displayName={self.state.displayName} side="right" isSignedIn={SESSION.active()} />
                     </nav>
                 </div>
             </header>

--- a/src/js/components/wonderland/SiteNavigation.js
+++ b/src/js/components/wonderland/SiteNavigation.js
@@ -43,7 +43,8 @@ var SiteNavigation = React.createClass({
                 accountSettingsPage: <Link to={UTILS.DRY_NAV.ACCOUNTSETTINGS.URL} title={T.get('nav.accountSettings')}>{T.get('nav.accountSettings')}</Link>,
                 userSettingsPage: <Link to={UTILS.DRY_NAV.USERSETTINGS.URL} title={T.get('nav.userSettings')}>{T.get('nav.userSettings')}</Link>,
                 integrationsPage: <Link to={UTILS.DRY_NAV.INTEGRATIONS.URL} title={T.get('nav.integrations')}>{T.get('nav.integrations')}</Link>,
-            },  
+                avatar: <img className="wonderland-navbar__avatar" src={self.props.avatar} alt={self.props.displayName} title={self.props.displayName} />
+            },
             accountSettings = <span>
                                     <div className="wonderland-navbar__icon wonderland-navbar__icon--regular"><i className="fa fa-cog" aria-hidden="true" /></div>
                                     <ul className="box wonderland-navbar__subnav">
@@ -55,7 +56,7 @@ var SiteNavigation = React.createClass({
                                     </ul>
                                 </span>,
             userSettings = <span>
-                                <div className="wonderland-navbar__icon wonderland-navbar__icon--alternate"><i className="fa fa-user" aria-hidden="true" /></div>
+                                {items.avatar}
                                 <ul className="box wonderland-navbar__subnav">
                                     <li>{items.userSettingsPage}</li>
                                     <li>{items.billingPage}</li>

--- a/src/js/modules/translation.js
+++ b/src/js/modules/translation.js
@@ -167,6 +167,7 @@ const _DEFAULT_LOCALE = 'en-US',
             'label.stagingTrackerAccountId' : 'Staging Tracker Account ID',
             'label.accountName' : 'Account Name',
             'label.accountId' : 'Account ID',
+            'label.avatar' : 'Avatar',
             // Created
             // Updated
             'label.servingEnabled' : 'Serving Enabled',


### PR DESCRIPTION
# Changes
- added `npm` package
- added call to `SiteBanner` to pull in an avatar URL and pass to
  `SiteNavigation`
- consolidated the `setState` call
- removing `isMounted` protection and no longer used functions
- add read-only avatar to User Settings
# Test Plan
- check correct Gravatar pulled in if signed in known-to-Gravatar email address, on both User Settings and top navigation
- check random generated Gravatar pulled in if signed in with unknown-to-Gravatar email address, on both User Settings and top navigation
