### PR TITLE
Thumbnail Modal (sometimes enabling/disabling causes a jump) #1046

### DIFF
--- a/src/js/components/wonderland/Thumbnails.js
+++ b/src/js/components/wonderland/Thumbnails.js
@@ -43,7 +43,8 @@ var Thumbnails = React.createClass({
         ;
         newThumbnails[index].enabled = !newThumbnails[index].enabled;
         self.setState({
-            thumbnails: newThumbnails
+            thumbnails: newThumbnails,
+            selectedItem: index
         });
     },
     handleToggleModal: function(selectedItem) {


### PR DESCRIPTION
- when we toggle we need to tell the `Thumbnails` component that the
  new `selectedItem` is the number in question (we don’t update on the
  Carousel previous and next) otherwise when we set the state it reverts
  to the old `selectedItem`
