### PR TITLE
Image Modal Tweaks #1085

### DIFF
--- a/src/js/components/pages/SupportPage.js
+++ b/src/js/components/pages/SupportPage.js
@@ -34,7 +34,7 @@ var SupportPage = React.createClass({
                     body: <SupportTab3 />
                 },
                 {
-                    label: 'Reference',
+                    label: 'API',
                     body: <SupportTab4 />
                 },
                 {

--- a/src/js/components/wonderland/ThumbnailInfoBox.js
+++ b/src/js/components/wonderland/ThumbnailInfoBox.js
@@ -59,7 +59,7 @@ var ThumbnailInfoBox = React.createClass({
                 <dl className="wonderland-dl">
                     <dt
                         className={'wonderland-dt' + (self.props.frameNo > 0 ? '' : ' is-hidden')}
-                        dangerouslySetInnerHTML={{__html: T.get('copy.frameNo')}}
+                        dangerouslySetInnerHTML={{__html: T.get('copy.frame')}}
                     />
                         <dd className={'wonderland-dd' + (self.props.frameNo > 0 ? '' : ' is-hidden')}>
                             {self.props.frameNo}
@@ -68,8 +68,8 @@ var ThumbnailInfoBox = React.createClass({
                         <dd className="wonderland-dd">{self.props.type}</dd>
                     <dt className="wonderland-dt">{T.get('copy.dimensions')}</dt>
                         <dd className="wonderland-dd">{self.props.width}x{self.props.height}</dd>
-                    <dt className="wonderland-dt">{T.get('copy.thumbnailId')}</dt>
-                        <dd className="wonderland-dd">{self.props.thumbnailId}</dd>
+                    <dt className="is-hidden wonderland-dt">{T.get('copy.thumbnailId')}</dt>
+                        <dd className="is-hidden wonderland-dd">{self.props.thumbnailId}</dd>
                     <dt className="wonderland-dt">{T.get('copy.created')}</dt>
                         <dd className="wonderland-dd">
                             <FuzzyTime date={self.props.created} />

--- a/src/js/modules/translation.js
+++ b/src/js/modules/translation.js
@@ -166,7 +166,7 @@ const _DEFAULT_LOCALE = 'en-US',
             'copy.thumbnailId': 'Thumbnail ID',
             'copy.created' : 'Created',
             'copy.updated' : 'Updated',
-            'copy.frameNo' : 'Frame <abbr title="Number">No.</abbr>',
+            'copy.frame' : 'Frame',
             'copy.ctr' : '<abbr title="Click Through Rate">CTR</abbr>',
 
             'copy.unknown': 'Unknown',


### PR DESCRIPTION
- renamed `Reference` tab to `API`
- change `Frame No` to `Frame`
- hide `thumbnailId` on `ThumbnailInfoBox`
