### PR TITLE
FrontEnd: ThumbnailStats: slows down paging #1093

### DIFF
--- a/src/js/components/wonderland/ThumbnailInfoBox.js
+++ b/src/js/components/wonderland/ThumbnailInfoBox.js
@@ -18,39 +18,23 @@ var ThumbnailInfoBox = React.createClass({
         height: React.PropTypes.number,
         thumbnailId: React.PropTypes.string,
         created: React.PropTypes.string.isRequired,
-        updated: React.PropTypes.string.isRequired
+        updated: React.PropTypes.string.isRequired,
+        thumbnailStats: React.PropTypes.object
     },
     getInitialState: function() {
         return({
             ctr: T.get('copy.unknown')
         })
     },
-    componentWillMount: function() {
-        var self = this,
-            options = {
-                data: {
-                    thumbnail_id: self.props.thumbnailId,
-                    // Comma-separated string of fields to return. Can include
-                    // serving_frac (the fraction of traffic seeing this
-                    // thumbnail), ctr (the click-through rate), impressions
-                    // (the number of impressions), conversions (the number
-                    // of conversions), created, and updated.
-                    fields: 'ctr'
-                }
+    componentWillReceiveProps: function(nextProps) {
+        var self = this;
+        if (nextProps.thumbnailStats && nextProps.thumbnailStats.hasOwnProperty('ctr')) {
+            if (nextProps.thumbnailStats.ctr !== self.state.ctr) {
+                self.setState({
+                    ctr: nextProps.thumbnailStats.ctr
+                });
             }
-        ;
-        self.GET('statistics/thumbnails', options)
-        .then(function(json) {
-            var ctr = json.statistics[0].ctr; 
-            self.setState({
-                ctr: ctr ? UTILS.formatCtr(ctr) : T.get('copy.na')
-            });
-        })
-        .catch(function(err) {
-            // If this errors, we don't want to shout it. It can just
-            // gracefully not work.
-            console.log(err);
-        });
+        }
     },
     render: function() {
         var self = this;
@@ -82,7 +66,7 @@ var ThumbnailInfoBox = React.createClass({
                         className="wonderland-dt"
                         dangerouslySetInnerHTML={{__html: T.get('copy.ctr')}}
                     />
-                        <dd className="wonderland-dd">{self.state.ctr}</dd>
+                        <dd className="wonderland-dd">{UTILS.formatCtr(self.state.ctr)}</dd>
                 </dl>
             </aside>
         );

--- a/src/js/components/wonderland/Video.js
+++ b/src/js/components/wonderland/Video.js
@@ -141,6 +141,7 @@ var Video = React.createClass({
                         thumbnails={self.state.sortedThumbnails}
                     />
                     <VideoMain
+                        videoId={self.state.videoId}
                         forceOpen={self.state.forceOpen}
                         messageNeeded={messageNeeded}
                         thumbnails={self.state.sortedThumbnails}

--- a/src/js/components/wonderland/VideoMain.js
+++ b/src/js/components/wonderland/VideoMain.js
@@ -10,6 +10,7 @@ import VideoInfoBox from './VideoInfoBox';
 var VideoMain = React.createClass({
 	// mixins: [ReactDebugMixin],
     propTypes: {
+        videoId: React.PropTypes.string.isRequired,
         forceOpen: React.PropTypes.bool.isRequired,
         messageNeeded: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.object]).isRequired,
         thumbnails: React.PropTypes.array.isRequired,
@@ -35,6 +36,7 @@ var VideoMain = React.createClass({
                             videoState={self.props.videoState}
                             forceOpen={self.props.forceOpen}
                             isServingEnabled={self.props.isServingEnabled}
+                            videoId={self.props.videoId}
                         />
                     </div>
                     <aside className="column is-12-mobile is-2-desktop">


### PR DESCRIPTION
- pass `videoId` down into `VideoMain` and `Thumbnails`
- if we are opening up the `Thumbnails` to see them, make an Ajax call
  in anticipation for the stats
- pass the stats to the `ThumbnailInfoBox`
- now on page load we do 0 stats calls
- when we open up a Video, 1 stat call
