### PR TITLE
Empty Results Section #1236

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "browser-sync": "^2.9.11",
     "browserify": "^11.2.0",
     "connect-history-api-fallback": "^1.1.0",
-    "gulp": "^3.9.1",
+    "gulp": "^3.9.0",
     "gulp-clean": "^0.3.2",
     "gulp-concat-css": "^2.3.0",
     "gulp-if": "^2.0.1",


### PR DESCRIPTION
# Changes
- added to `additionalClass` variable of `VideosResults` table that adds `.is-hidden` when `self.props.videoCountedServed` is less than or equal to zero
# Test Plan
- sign into an account without videos
  - make sure VideosResults section is not visible
  - sign out
- sign into an account with videos
  - make sure VideosResults section is visible and populated with results
