### PR TITLE
Result Pages that Works Without Logging In #1150

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -157,7 +157,8 @@ gulp.task('browser-sync', function() {
             rewrites: [{
                 from: /\/video\/.*/, to: '/index.html',
                 from: /\/account\/confirm\/.*/, to: '/index.html',
-                from: /\/user\/reset\/token\/.*/, to: '/index.html'
+                from: /\/user\/reset\/token\/.*/, to: '/index.html',
+                from: /\/share\/.*/, to: '/index.html'
             }]
         })],
         ghostMode: false

--- a/src/js/components/core/Carousel.js
+++ b/src/js/components/core/Carousel.js
@@ -99,7 +99,10 @@ var Carousel = React.createClass({
                             className={UTILS.buildTooltipClass('wonderland-carousel__control wonderland-carousel__control--previous', 'right')}
                             aria-label={T.get('action.previous')}
                         >
-                            <Icon type="chevron-circle-left" />
+                            <Icon
+                                type="chevron-circle-left"
+                                nowrap={true}
+                            />
                         </li>
                         <li>Item {self.state.selectedItem + 1} of {self.state.total}</li>
                         <li
@@ -107,7 +110,10 @@ var Carousel = React.createClass({
                             className={UTILS.buildTooltipClass('wonderland-carousel__control wonderland-carousel__control--next', 'left')}
                             aria-label={T.get('action.next')}
                         >
-                            <Icon type="chevron-circle-right" />
+                            <Icon
+                                type="chevron-circle-right"
+                                nowrap={true}
+                            />
                         </li>
                     </ul>
                 </nav>

--- a/src/js/components/pages/VideoPageGuest.js
+++ b/src/js/components/pages/VideoPageGuest.js
@@ -1,0 +1,42 @@
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+import React from 'react';
+// import ReactDebugMixin from 'react-debug-mixin';
+import SiteHeader from '../wonderland/SiteHeader';
+import SiteFooter from '../wonderland/SiteFooter';
+import VideoGuest from '../wonderland/VideoGuest';
+import Helmet from 'react-helmet';
+import UTILS from '../../modules/utils';
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+var VideoPageGuest = React.createClass({
+    // mixins: [ReactDebugMixin],
+    render: function() {
+        var self = this;
+        return (
+            <div>
+                <Helmet
+                    title={UTILS.buildPageTitle('Video')}
+                />
+                <SiteHeader />
+                <section className="wonderland-section section">
+                    <div className="container">
+                        <VideoGuest
+                            videoId={self.props.params.videoId}
+                            accountId={self.props.params.accountId}
+                            shareToken={self.props.params.shareToken}
+                        />
+                    </div>
+                </section>
+                <SiteFooter />
+            </div>
+        );
+    }
+});
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+export default VideoPageGuest;
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/js/components/wonderland/Hud.js
+++ b/src/js/components/wonderland/Hud.js
@@ -11,13 +11,14 @@ import T from '../../modules/translation';
 var Hud = React.createClass({
     // mixins: [ReactDebugMixin],
     propTypes: {
+        isGuest: React.PropTypes.bool.isRequired,
         stats: React.PropTypes.object
     },
     render: function() {
-        var self = this
-            //,
-            //neonScore = UTILS.NEON_SCORE_ENABLED ? <li><Icon type="neon" title="Neonscore" />{self.props.cookedNeonScore}</li> : false
-        ;
+        var self = this;
+        if (self.props.isGuest) {
+            return false;
+        }
         if (self.props.stats) {
             return (
                 <ul className="wonderland-hud">

--- a/src/js/components/wonderland/Thumbnail.js
+++ b/src/js/components/wonderland/Thumbnail.js
@@ -15,6 +15,7 @@ import Hud from './Hud';
 var Thumbnail = React.createClass({
     mixins: [AjaxMixin], // ReactDebugMixin
     propTypes: {
+        isGuest: React.PropTypes.bool.isRequired,
         isEnabled: React.PropTypes.bool.isRequired,
         index: React.PropTypes.number.isRequired,
         rawNeonScore: React.PropTypes.oneOfType([React.PropTypes.number, React.PropTypes.string]),
@@ -130,6 +131,7 @@ var Thumbnail = React.createClass({
                     </figcaption>
                 </figure>
                 <Hud
+                    isGuest={self.props.isGuest}
                     stats={self.props.thumbnailStats}
                     cookedNeonScore={self.props.cookedNeonScore}
                 />

--- a/src/js/components/wonderland/Thumbnails.js
+++ b/src/js/components/wonderland/Thumbnails.js
@@ -20,6 +20,7 @@ import AjaxMixin from '../../mixins/Ajax';
 var Thumbnails = React.createClass({
     mixins: [AjaxMixin], // ReactDebugMixin
     propTypes: {
+        isGuest: React.PropTypes.bool.isRequired,
         videoState: React.PropTypes.string.isRequired,
         thumbnails: React.PropTypes.array.isRequired,
         forceOpen: React.PropTypes.bool.isRequired,
@@ -44,12 +45,7 @@ var Thumbnails = React.createClass({
             self.GET('statistics/thumbnails', {
                 data: {
                     video_id: self.props.videoId,
-                    // Comma-separated string of fields to return. Can include
-                    // serving_frac (the fraction of traffic seeing this
-                    // thumbnail), ctr (the click-through rate), impressions
-                    // (the number of impressions), conversions (the number
-                    // of conversions), created, and updated.
-                    fields: ['thumbnail_id', 'ctr', 'serving_frac', 'impressions', 'conversions', 'created', 'updated']
+                    fields: UTILS.THUMBNAIL_FIELDS
                 }
             })
             .then(function(json) {
@@ -115,6 +111,7 @@ var Thumbnails = React.createClass({
                                 rawNeonScore = UTILS.NEON_SCORE_ENABLED ? thumbnail.neon_score : 0,
                                 cookedNeonScore = UTILS.NEON_SCORE_ENABLED ? neonScoreData.neonScore : 0,
                                 thumbnailElement = <Thumbnail
+                                        isGuest={self.props.isGuest}
                                         index={i}
                                         isEnabled={thumbnail.enabled}
                                         strippedUrl={UTILS.stripProtocol(thumbnail.url)}

--- a/src/js/components/wonderland/VideoGuest.js
+++ b/src/js/components/wonderland/VideoGuest.js
@@ -1,0 +1,141 @@
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+import React from 'react';
+// import ReactDebugMixin from 'react-debug-mixin';
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+import Message from './Message';
+import UTILS from '../../modules/utils';
+import AjaxMixin from '../../mixins/Ajax';
+import VideoHeader from './VideoHeader';
+import VideoMain from './VideoMain';
+import T from '../../modules/translation';
+import E from '../../modules/errors';
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+var VideoGuest = React.createClass({
+    mixins: [AjaxMixin], // ReactDebugMixin
+    propTypes: {
+        videoId: React.PropTypes.string.isRequired,
+        accountId: React.PropTypes.string.isRequired,
+        shareToken: React.PropTypes.string.isRequired
+    },
+    getInitialState: function() {
+        var self = this;
+        return {
+            videoId: self.props.videoId,
+            accountId: self.props.accountId,
+            shareToken: self.props.shareToken,
+            videoState: 'unknown',
+            thumbnails: [],
+            sortedThumbnails: [],
+            title: 'Unknown',
+            duration: 0,
+            created: '',
+            url: '',
+            mode: 'quiet' // quiet/loading/error/success
+        }
+    },
+    componentDidMount: function() {
+        var self = this;
+        self.setState({
+            mode: 'loading'
+        }, function() {
+            self.GET('videos', {
+                overrideAccountId: self.props.accountId,
+                data: {
+                    video_id: self.props.videoId,
+                    share_token: self.props.shareToken,
+                    fields: UTILS.VIDEO_FIELDS
+                }
+            })
+                .then(function(json) {
+                    var video = json.videos[0];
+                    self.setState({
+                        mode: 'success',
+                        title: video.title,
+                        duration: video.duration,
+                        url: video.url,
+                        thumbnails: video.thumbnails,
+                        sortedThumbnails: UTILS.fixThumbnails(video.thumbnails),
+                        videoState: video.state,
+                        videoStateMapping: UTILS.VIDEO_STATE[video.state].mapping,
+                        created: video.created
+                    });
+                })
+                .catch(function(err) {
+                    E.raiseError(err);
+                    self.setState({
+                        mode: 'error'
+                    });
+                });
+            })
+        ;
+    },
+    render: function() {
+        var self = this;
+        // TODO - API Call
+        switch(self.state.mode) {
+            case 'quiet':
+                return (
+                    <div></div>
+                );
+                break;
+            case 'loading':
+                return (
+                    <div></div>
+                );
+                break;
+            case 'error':
+                return (
+                    <Message header={'ERROR Heading TODO'} body={E.getErrors()} flavour="danger" />
+                );
+                break;
+            case 'success':
+                var additionalClass = 'wonderland-video--state button is-' + self.state.videoStateMapping + ' is-small',
+                    videoSizeClass = 'video video--big'
+                ;
+                return (
+                    <div className={videoSizeClass}>
+                        <VideoHeader
+                            isGuest={true}
+                            showVideoOpenToggle={false}
+                            forceOpen={true}
+                            additionalClass={additionalClass}
+                            videoState={self.state.videoState}
+                            title={self.state.title}
+                            videoId={self.state.videoId}
+                            created={self.state.created}
+                            thumbnails={self.state.sortedThumbnails}
+                        />
+                        <VideoMain
+                            isGuest={true}
+                            videoId={self.state.videoId}
+                            forceOpen={true}
+                            messageNeededComponent={false}
+                            thumbnails={self.state.sortedThumbnails}
+                            videoState={self.state.videoState}
+                            duration={self.state.duration}
+                            created={self.state.created}
+                            url={self.state.url}
+                            isServingEnabled={false}
+                            shareToken={self.state.shareToken}
+                            accountId={self.state.accountId}
+                        />
+                    </div>
+                );
+                break;
+        }
+    },
+    componentWillUnmount: function(e) {
+        E.clearErrors();
+    },
+});
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+export default VideoGuest;
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/js/components/wonderland/VideoHeader.js
+++ b/src/js/components/wonderland/VideoHeader.js
@@ -15,6 +15,7 @@ import Icon from '../core/Icon';
 var VideoHeader = React.createClass({
     // mixins: [ReactDebugMixin],
     propTypes: {
+        isGuest: React.PropTypes.bool.isRequired,
         handleVideoOpenToggle: React.PropTypes.func,
         showVideoOpenToggle: React.PropTypes.bool.isRequired,
         forceOpen: React.PropTypes.bool.isRequired,

--- a/src/js/components/wonderland/VideoInfoBox.js
+++ b/src/js/components/wonderland/VideoInfoBox.js
@@ -9,23 +9,26 @@ import UTILS from '../../modules/utils';
 var VideoInfoBox = React.createClass({
     // mixins: [ReactDebugMixin],
     propTypes: {
-        videoLink: React.PropTypes.string.isRequired,
-        duration: React.PropTypes.number,
+        isGuest: React.PropTypes.bool.isRequired,
+        videoLink: React.PropTypes.string,
+        duration: React.PropTypes.number.isRequired,
         url: React.PropTypes.string.isRequired
     },
     render: function() {
         var self = this,
-            niceDuration = UTILS.formatDuration(self.props.duration)
+            niceDuration = UTILS.formatDuration(self.props.duration),
+            videoLinkClass = (self.props.videoLink ? '' : ' is-hidden'),
+            durationClass = (self.props.duration === 0 ? ' is-hidden' : '')
         ;
         return (
             <aside className="box wonderland-box">
                 <dl className="wonderland-dl">
-                    <dt className="wonderland-dt">Duration</dt>
-                        <dd className="wonderland-dd">{niceDuration}</dd>
+                    <dt className={'wonderland-dt' + durationClass}>Duration</dt>
+                        <dd className={'wonderland-dd' + durationClass}>{niceDuration}</dd>
                     <dt className="wonderland-dt">Original</dt>
                         <dd className="wonderland-dd"><a href={self.props.url} rel="external">Link</a></dd>
-                    <dt className="wonderland-dt">Direct</dt>
-                        <dd className="wonderland-dd"><a href={self.props.videoLink}>Link</a></dd>
+                    <dt className={'wonderland-dt' + videoLinkClass}>Direct</dt>
+                        <dd className={'wonderland-dd' + videoLinkClass}><a href={self.props.videoLink}>Link</a></dd>
                 </dl>
             </aside>
         );

--- a/src/js/components/wonderland/VideoMain.js
+++ b/src/js/components/wonderland/VideoMain.js
@@ -11,12 +11,14 @@ import VideoSharer from './VideoSharer';
 var VideoMain = React.createClass({
     // mixins: [ReactDebugMixin],
     propTypes: {
+        isGuest: React.PropTypes.bool.isRequired,
+        accountId: React.PropTypes.string,
         videoId: React.PropTypes.string.isRequired,
         forceOpen: React.PropTypes.bool.isRequired,
-        messageNeededComponent: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.object]).isRequired,
+        messageNeededComponent: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.bool, React.PropTypes.object]).isRequired,
         thumbnails: React.PropTypes.array.isRequired,
         videoState: React.PropTypes.string.isRequired,
-        videoLink: React.PropTypes.string.isRequired,
+        videoLink: React.PropTypes.string,
         duration: React.PropTypes.number.isRequired,
         url: React.PropTypes.string.isRequired,
         created: React.PropTypes.string,
@@ -34,6 +36,7 @@ var VideoMain = React.createClass({
                     <div className="column is-12-mobile is-10-desktop">
                         {self.props.messageNeededComponent}
                         <Thumbnails
+                            isGuest={self.props.isGuest}
                             thumbnails={self.props.thumbnails}
                             videoState={self.props.videoState}
                             forceOpen={self.props.forceOpen}
@@ -43,13 +46,16 @@ var VideoMain = React.createClass({
                     </div>
                     <aside className="column is-12-mobile is-2-desktop">
                         <VideoInfoBox
+                            isGuest={self.props.isGuest}
                             videoLink={self.props.videoLink}
                             duration={self.props.duration}
                             url={self.props.url}
                         />
                         <VideoSharer
+                            isGuest={self.props.isGuest}
                             shareToken={self.props.shareToken}
                             videoId={self.props.videoId}
+                            accountId={self.props.accountId}
                         />
                     </aside>
                 </div>

--- a/src/js/components/wonderland/VideoOwner.js
+++ b/src/js/components/wonderland/VideoOwner.js
@@ -93,6 +93,7 @@ var VideoOwner = React.createClass({
             return (
                 <div className={videoSizeClass}>
                     <VideoHeader
+                        isGuest={false}
                         handleVideoOpenToggle={self.handleVideoOpenToggle}
                         forceOpen={self.state.forceOpen}
                         videoState={self.state.videoState}
@@ -104,6 +105,7 @@ var VideoOwner = React.createClass({
                         showVideoOpenToggle={true}
                     />
                     <VideoMain
+                        isGuest={false}
                         videoId={self.state.videoId}
                         forceOpen={self.state.forceOpen}
                         messageNeededComponent={messageNeededComponent}

--- a/src/js/modules/ajax.js
+++ b/src/js/modules/ajax.js
@@ -58,7 +58,10 @@ var AJAXModule = {
                 _options.type = 'json';
                 _options.contentType = 'application/json';
             }
-            _options.url = _options.host + (_options.host === CONFIG.API_HOST ? self.Session.state.accountId + '/' : '') + _url;
+
+            var accountIdToUse = (_options.overrideAccountId ? _options.overrideAccountId : self.Session.state.accountId);
+            _options.url = _options.host + (_options.host === CONFIG.API_HOST ? accountIdToUse + '/' : '') + _url;
+            
             _options.shouldRetry = (_options.shouldRetry !== false);  // default to true
             reqwest(_options)
                 .then(function (res) {
@@ -104,19 +107,9 @@ var AJAXModule = {
         options.errorHandler = options.errorHandler || self.handleApiError;
 
         promise = new Promise(function (resolve, reject) {
-            var authUrl = '',
-                err;
-            if (self.Session.active() === true || options.host === CONFIG.AUTH_HOST) {
-                fin.call(self, resolve, reject);
-            } else {
-                // We're missing an account id, so simulate an "unauthorized" response from the server
-                err = {
-                    error: 'Unauthorized',
-                    code: 401
-                };
-                options.errorHandler ? reject(options.errorHandler(err)) : reject(err);
-            }
+            fin.call(self, resolve, reject);
         });
+
         ret = {
             isCanceled: false,
             cancel: function() {

--- a/src/js/modules/utils.js
+++ b/src/js/modules/utils.js
@@ -239,6 +239,7 @@ var UTILS = {
     VIDEO_CHECK_INTERVAL_BASE: 10000, // 10s
     RESULTS_PAGE_SIZE: 10,
     VIDEO_FIELDS: ['video_id', 'title', 'publish_date', 'created', 'updated', 'duration', 'state', 'url', 'thumbnails'],
+    THUMBNAIL_FIELDS: ['thumbnail_id', 'ctr', 'serving_frac', 'impressions', 'conversions', 'created', 'updated'],
     BITLY_ACCESS_TOKEN: 'c9f66d34107cef477d4d1eaca40b911f6f39377e',
     BITLY_SHORTEN_URL: 'https://api-ssl.bitly.com/v3/shorten',
     rando: function(num) {
@@ -321,9 +322,9 @@ var UTILS = {
         ;
         return hash64.str();
     },
-    // http://stackoverflow.com/questions/1353684/detecting-an-invalid-date-date-instance-in-javascript
     isValidDate: function(d) {
-        return !isNaN(Date.parse(d));
+        var niceDate = d.split(' ').join('T'); // hackety hack hack ugh spit
+        return !isNaN(Date.parse(niceDate));
     },
     buildTooltipClass: function(existingClass, position) {
         // https://github.com/chinchang/hint.css

--- a/src/js/wonderland.js
+++ b/src/js/wonderland.js
@@ -19,6 +19,7 @@ import NotFoundPage from './components/pages/NotFoundPage';
 import AnalyzeVideoPage from './components/pages/AnalyzeVideoPage';
 import VideosPage from './components/pages/VideosPage';
 import VideoPageOwner from './components/pages/VideoPageOwner';
+import VideoPageGuest from './components/pages/VideoPageGuest';
 import HomePage from './components/pages/HomePage';
 import DashboardPage from './components/pages/DashboardPage';
 import PendingAccountPage from './components/pages/PendingAccountPage';
@@ -72,6 +73,8 @@ render((
         <Route path={UTILS.DRY_NAV.VIDEO_ANALYZE.URL} component={AnalyzeVideoPage} />
         <Route path={UTILS.DRY_NAV.VIDEO_LIBRARY.URL} component={VideosPage} />
         <Route path="/video/:videoId/" component={VideoPageOwner} />
+
+        <Route path="/share/video/:videoId/account/:accountId/token/:shareToken/" component={VideoPageGuest} />
 
         <Route path={UTILS.DRY_NAV.TERMS.URL} component={TermsPage} />
         <Route path={UTILS.DRY_NAV.BILLING.URL} component={BillingPage} />


### PR DESCRIPTION
![giphy](https://cloud.githubusercontent.com/assets/1378582/16136011/1136bb32-33dc-11e6-9864-3561255f342c.gif)
# CHANGES
- updated `gulpfile` with potentially period filled path
- `VideoGuest` and `VideoPageGuest` added
- added new route
- fixing some unwrapped `Icon`s
- turned off 'Hud' in Guest mode and other UI
- new prop - `isGuest` to help with rendering
- new `THUMBNAIL_FIELDS` constant
- updated `VideoSharer` to allow resharing
- added an `overrideAccountId` option to `Ajax`
# TEST PLAN
## Part 1
- Login, find a Video
- Get its Share URL (Info Box, temp Share button), copy
- Goto Anonymous Window
- Paste URL, make sure you can see the pared down results
- Try this with a few videos please
## Part 2
- Goto one of the Anonymous windows
- get the Share URL as above and ensure its the same URL (the app shouldn't be doing any API calls to work it out)
- Copy as before and paste as before, make sure it works
- Do this until you reach infinity
