### PR TITLE
VideosResults Edge Case #NoTicket

### DIFF
--- a/src/js/components/wonderland/VideosResults.js
+++ b/src/js/components/wonderland/VideosResults.js
@@ -13,7 +13,7 @@ var VideosResults = React.createClass({
     render: function() {
         var self = this,
             additionalClass = 'table is-bordered' + (self.props.isLoading ? ' is-loading' : '') 
-            + ((self.props.videoCountServed <= 0 && self.props.alertMessage === '') ? ' is-hidden' : '')
+            + ((self.props.videoCountServed === 0 && self.props.alertMessage === '') ? ' is-hidden' : '')
         ;
         return (
             <table className={additionalClass}>


### PR DESCRIPTION
Edge Case: If the user has uploaded exactly 10 videos and they attempted to click "next", `VideosResults` will not appear despite containing a `Message` component.

Fix: Adjust the `additionalClass` condition to check that `self.props.videoCountServed` is 0 and `self.props.alertMessage` is an empty string.
