### PR TITLE
HOT: All Neonscores are 99

### DIFF
--- a/src/js/modules/utils.js
+++ b/src/js/modules/utils.js
@@ -213,7 +213,7 @@ var UTILS = {
             URL: '/video/analyze/'
         }
     },
-    VERSION: '1.9',
+    VERSION: '1.9.1',
     NEON_SCORE_ENABLED: true,
     DEFAULT_SERVING_STATE: false,
     CONTACT_EXTERNAL_URL: 'https://neon-lab.com/contact-us/',


### PR DESCRIPTION
- since Neonscoring is now done in the back end, update our
  `getNeonScoreData` function to no longer loop through our
  transformation function and instead just grab the emoji and pass on
  through (tidy up will happen here at a later date)
