### PR TITLE
Fix IE bugs due to strict mode & navigator.language not existing

### DIFF
--- a/src/js/components/pages/IntegrationsBrightcovePage.js
+++ b/src/js/components/pages/IntegrationsBrightcovePage.js
@@ -18,11 +18,6 @@ import Account from '../../mixins/Account';
 
 var IntegrationsBrightcovePage = React.createClass({
     mixins: [Secured, AjaxMixin, Account], // ReactDebugMixin
-    componentWillMount: function() {
-        var self = this
-        ;
-        self.refreshNeonAccountInfo();
-    },
     getInitialState: function() {
         var self = this,
             params = self.props.routeParams,

--- a/src/js/modules/translation.js
+++ b/src/js/modules/translation.js
@@ -233,7 +233,6 @@ const _DEFAULT_LOCALE = 'en-US',
             'copy.servingFraction': 'Serving Fraction',
             'copy.impressions': 'Impressions',
             'copy.conversions': 'Conversions',
-            'copy.ctr': 'CTR',
             'copy.neonScoreEquals': 'NeonScore of @neonscore',
             'copy.bestThumbnail': 'Best Thumbnail',
             'copy.signedInAs': 'Signed In as @user',
@@ -310,8 +309,9 @@ const _DEFAULT_LOCALE = 'en-US',
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 function _getLocale() {
-    var locale = navigator.language.split('-');
-    locale = locale[1] ? `${locale[0]}-${locale[1].toUpperCase()}` : navigator.language;
+    var language = navigator.language || navigator.userLanguage;
+    var locale = language.split('-');
+    locale = locale[1] ? `${locale[0]}-${locale[1].toUpperCase()}` : language;
     return locale;
 }
 


### PR DESCRIPTION
**First issue:** IE is pretty strict about strict mode so re-declaring `componentWillMount` & `copy.ctr` breaks IE10 & IE11

**Second issue:** `navigator.language` is not a thing on IE9 & IE10, so just check for userLanguage if it doesn't exist

I realize this is probably not a priority but I had to fix it for myself so I could test the new design in IE9+. Thought I might as well do a pull request.

Let me know if you want anything adjusted.
