### PR TITLE
Change opacity of score box on image zoom view #1309

### DIFF
--- a/src/css/xx/components/_thumbnail.scss
+++ b/src/css/xx/components/_thumbnail.scss
@@ -63,6 +63,9 @@ $thumbnail-hover-border: 2px;
         &::before {
             display: none;
         }
+        &::after {
+            background-color: rgba($accent-color, 0.9);
+        }
     }
 }
 


### PR DESCRIPTION
# Changes
- special case for background colour in image zoom only
# Test Plan
- make sure Daddy default thumbnail is still gray solid
- make sure Mummy thumbnail (large) is still orange solid
- make sure Child thumbnail (regular) is still orange solid
- make sure zoomed in thumbnail is 90% opaque orange
