### PR TITLE
Example of handling ImageZoom scroll position #1311

### DIFF
--- a/src/css/xx/components/_overlay.scss
+++ b/src/css/xx/components/_overlay.scss
@@ -7,6 +7,11 @@
 }
 
 .has-overlayWithScroll {
+    overflow: hidden;
+}
+
+.has-overlayWithNav {
+    overflow-x: auto;
     overflow-y: hidden;
 
     #wonderland {
@@ -33,15 +38,15 @@
     &--scroll {
         overflow-x: visible;
         overflow-y: scroll;
+    }
+
+    &--visibleNav {
+        z-index: $zindex-header - 1;
         min-width: $page-min-width + $gutter-width * 2;
 
         @media (max-width: $page-min-width + $gutter-width * 2) {
             position: absolute;
         }
-    }
-
-    &--visibleNav {
-        z-index: $zindex-header - 1;
     }
 }
 

--- a/src/css/xx/layout/_image-overlay.scss
+++ b/src/css/xx/layout/_image-overlay.scss
@@ -1,3 +1,5 @@
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
 $zoom-image-max-width: calc((99.9% - #{$gutter-width}) * 2/3 - #{$gutter-width});
 
 $zoom-image-max-height: calc(100vh - (#{$header-height} + #{$header-margin-bottom}) * 2);

--- a/src/js/components/wonderland/Sidebar.js
+++ b/src/js/components/wonderland/Sidebar.js
@@ -29,13 +29,13 @@ var Sidebar = React.createClass({
             content: nextProps.content
         }, function() {
             if (self.state.content === null) {
-                document.body.classList.remove('has-overlayWithScroll');
+                document.body.classList.remove('has-overlayWithNav');
                 document.body.style.marginRight = 0;
             }
             else {
                 window.scrollTo(0, 0);
                 ReactDOM.findDOMNode(self).scrollTop = 0;
-                document.body.classList.add('has-overlayWithScroll');
+                document.body.classList.add('has-overlayWithNav');
                 document.body.style.marginRight = `${scrollbarWidth}px`;
             }
         });
@@ -70,9 +70,9 @@ var Sidebar = React.createClass({
                 break;
         }
         return (
-            <div 
-                className="xxOverlay xxOverlay--scroll xxOverlay--visibleNav" 
-                onClick={self.handleClose} 
+            <div
+                className="xxOverlay xxOverlay--scroll xxOverlay--visibleNav"
+                onClick={self.handleClose}
                 hidden={isHidden}
             >
                 <a href="#" className="xxOverlay-close" onClick={self.handleClose}>{T.get('close')}</a>

--- a/src/js/xx/components/ImageZoom.js
+++ b/src/js/xx/components/ImageZoom.js
@@ -18,7 +18,6 @@ export default class XXPageOverlay extends React.Component {
     }
 
     componentDidMount() {
-        window.scrollTo(0, 0);
         ReactDOM.findDOMNode(this).scrollTop = 0;
 
         document.body.classList.add('has-overlayWithScroll', 'has-overlayDark');
@@ -40,7 +39,7 @@ export default class XXPageOverlay extends React.Component {
         const { handleBgCloseClick, handleCloseClick } = this;
 
         return (
-            <article className="xxOverlay xxOverlay--dark xxOverlay--scroll xxOverlay--visibleNav">
+            <article className="xxOverlay xxOverlay--dark xxOverlay--scroll">
                 <a href="" className="xxOverlay-close" onClick={handleCloseClick}>Close</a>
                 <div className="xxImageZoom">
                     <div className="xxImageZoom-inner">

--- a/src/js/xx/components/PageOverlay.js
+++ b/src/js/xx/components/PageOverlay.js
@@ -19,12 +19,12 @@ export default class XXPageOverlay extends React.Component {
         window.scrollTo(0, 0);
         ReactDOM.findDOMNode(this).scrollTop = 0;
 
-        document.body.classList.add('has-overlayWithScroll');
+        document.body.classList.add('has-overlayWithNav');
         document.body.style.marginRight = `${scrollbarWidth}px`;
     }
 
     componentWillUnmount() {
-        document.body.classList.remove('has-overlayWithScroll');
+        document.body.classList.remove('has-overlayWithNav');
         document.body.style.marginRight = 0;
     }
 


### PR DESCRIPTION
Here's a quick example of how the scroll position restoration could be handled. It doesn't work perfectly with the transition animation (xx-transitions) but it's better than making the navigation fixed when an overlay is activated & as a result breaking the site for anyone with a smaller screen. That said, this can be fixed when the site becomes fully responsive.
