### PR TITLE
[HOT] Expose Neonscore on Default Thumbnail #1312

### DIFF
--- a/src/js/components/wonderland/Thumbnail.js
+++ b/src/js/components/wonderland/Thumbnail.js
@@ -73,7 +73,7 @@ var Thumbnail = React.createClass({
             rubricClass = 'wonderland-thumbnail__rubric' + (self.props.type === 'default' ? '' : ' is-hidden'),
             figureClass = 'wonderland-thumbnail ' + (self.state.isEnabled ? 'is-wonderland-enabled' : 'is-wonderland-disabled') + ' -' + self.props.type,
             enabledIndicator = UTILS.enabledDisabledIcon(self.state.isEnabled), // we want the opposite
-            neonScore = (UTILS.NEON_SCORE_ENABLED && self.props.type === 'neon') ? <span className={neonScoreClass} title={T.get('neonScore')}><Icon type="neon" />&nbsp;{self.props.cookedNeonScore}</span> : false,
+            neonScore = UTILS.NEON_SCORE_ENABLED ? <span className={neonScoreClass} title={T.get('neonScore')}><Icon type="neon" />&nbsp;{self.props.cookedNeonScore}</span> : null,
             handleEnabledChangeHook = self.props.isServingEnabled ? self.handleEnabledChange : function() { return false; }
         ;
         return (

--- a/src/js/modules/utils.js
+++ b/src/js/modules/utils.js
@@ -14,7 +14,7 @@ shortid.characters('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWX
 
 var UNKNOWN_STRING = '?',
     UNKNOWN_EMOJI = '',
-    NA_STRING = 'n/a',
+    NA_STRING = '?',
     COOKIE_DEFAULT_PATH = '/',
     // DO NOT RELY ON THESE MODELSCORES
     NEONSCORES = [


### PR DESCRIPTION
- change `N/A` string to `?` so on older videos we get a question mark
- remove restriction on showing the NeonScore for type `neon` so that
  it renders for all (as long as NeonScore is enabled)
