### PR TITLE
Shared Video Title Missing #1331

### DIFF
--- a/src/js/components/wonderland/VideoGuest.js
+++ b/src/js/components/wonderland/VideoGuest.js
@@ -121,6 +121,7 @@ var VideoGuest = React.createClass({
                             url={self.state.url}
                             shareToken={self.state.shareToken}
                             accountId={self.state.accountId}
+                            title={self.state.title}
                         />
                 );
                 break;


### PR DESCRIPTION
# Changes
- added missing prop to `VideoMain`
# Test Plan
- check that title is visible on shared video page
