### PR TITLE
Score colour #1359

### DIFF
--- a/src/css/xx/components/_thumbnail.scss
+++ b/src/css/xx/components/_thumbnail.scss
@@ -26,7 +26,6 @@ $thumbnail-hover-border: 2px;
         left: 0;
         width: $thumbnail-small-score-size;
         height: $thumbnail-small-score-size;
-        background-color: rgba($accent-color, 0.9);
         color: #fff;
         font-size: 14px;
         line-height: $thumbnail-small-score-size;
@@ -41,7 +40,13 @@ $thumbnail-hover-border: 2px;
         }
     }
 
-    &--lowScore {
+    &--highLight {
+        &::after {
+            background-color: rgba($accent-color, 0.9);
+        }
+    }
+
+    &--lowLight {
         &::after {
             background-color: $base-color;
         }

--- a/src/js/components/knave/FeatureThumbnail.js
+++ b/src/js/components/knave/FeatureThumbnail.js
@@ -27,7 +27,8 @@ var FeatureThumbnail = React.createClass({
             uid,
             handleChildOnMouseEnter,
             showHref,
-            src
+            src,
+            extraClass
         ;
         switch(self.props.type) {
             case 'default':
@@ -36,6 +37,7 @@ var FeatureThumbnail = React.createClass({
                 thumbnailId = null;
                 handleChildOnMouseEnter = null;
                 showHref = false;
+                extraClass = 'xxThumbnail--lowLight';
                 break;
             case 'neon':
                 uid = 0;
@@ -43,6 +45,7 @@ var FeatureThumbnail = React.createClass({
                 thumbnailId = self.props.thumbnails[uid].thumbnail_id;
                 handleChildOnMouseEnter = self.props.handleChildOnMouseEnter;
                 showHref = true;
+                extraClass = 'xxThumbnail--highLight';
                 break;
         }
         src = (self.state.renditionNumber === RENDITIONS.NO_RENDITION ? self.props.thumbnails[uid].url : self.props.thumbnails[uid].renditions[self.state.renditionNumber].url);
@@ -63,6 +66,7 @@ var FeatureThumbnail = React.createClass({
                     type={self.props.type}
                     isMobile={self.props.isMobile}
                     showHref={showHref}
+                    extraClass={extraClass}
                 />
             </div>
         );

--- a/src/js/components/knave/Thumbnail.js
+++ b/src/js/components/knave/Thumbnail.js
@@ -40,9 +40,6 @@ import UTILS from '../../modules/utils';
         if (self.props.type) {
             className.push('xxThumbnail--'+ self.props.type);
         }
-        if (self.props.score < UTILS.LOWSCORE_LIMIT) {
-            className.push('xxThumbnail--lowScore');
-        }
         return (
             <a
                 {...opts}

--- a/src/js/components/knave/ThumbnailCollection.js
+++ b/src/js/components/knave/ThumbnailCollection.js
@@ -40,6 +40,7 @@ var ThumbnailCollection = React.createClass({
                                     type={'regular'}
                                     src={src}
                                     isMobile={self.props.isMobile}
+                                    extraClass='xxThumbnail--lowLight'
                                 />
                             )
                         })
@@ -70,6 +71,7 @@ var ThumbnailCollection = React.createClass({
                                         handleChildOnMouseEnter={self.props.handleChildOnMouseEnter}
                                         handleClick={self.props.handleClick}
                                         isMobile={self.props.isMobile}
+                                        extraClass='xxThumbnail--highLight'
                                     />
                                 )
                             }

--- a/src/js/components/knave/ThumbnailOverlay.js
+++ b/src/js/components/knave/ThumbnailOverlay.js
@@ -59,6 +59,7 @@ var ThumbnailOverlay = React.createClass({
                                         handleClickNext={self.props.handleClickNext}
                                         displayThumbLift={self.props.displayThumbLift}
                                         valence={[tempValenceArray[Math.floor(Math.random() * tempValenceArray.length)]]}
+                                        extraClass={thumbnail.type === 'neon' ? 'xxThumbnail--highLight' : 'xxThumbnail--lowLight'}
                                     />
                                 );
                             })

--- a/src/js/components/knave/ZoomThumbnail.js
+++ b/src/js/components/knave/ZoomThumbnail.js
@@ -15,11 +15,13 @@ var ZoomThumbnail = React.createClass({
         total: React.PropTypes.number.isRequired,
         handleClickPrevious: React.PropTypes.func.isRequired,
         handleClickNext: React.PropTypes.func.isRequired,
-        valence: React.PropTypes.array.isRequired
+        valence: React.PropTypes.array.isRequired,
+        extraClass: React.PropTypes.string
     },
     render: function() {
         var self = this,
             activeClass = (self.props.index === self.props.selectedItem ? ' is-active' : ''),
+            extraClass = ['xxThumbnail--zoom'],
             w = self.props.thumbnail.width,
             h = self.props.thumbnail.height,
             orientation = (w === h) ? 'square' : ((w > h) ? 'landscape' : 'portrait'),
@@ -27,6 +29,9 @@ var ZoomThumbnail = React.createClass({
                 maxWidth: 'calc((100vh - 242px) / (' + h + ' / ' + w + '))'
             }
         ;
+        if (self.props.extraClass) {
+            extraClass.push(self.props.extraClass);
+        }
         return (
             <div className={'xxImageZoom-inner' + activeClass}>
                 <div
@@ -34,7 +39,7 @@ var ZoomThumbnail = React.createClass({
                     style={styleOpts}
                 >
                     <Thumbnail
-                        extraClass="xxThumbnail--zoom"
+                        extraClass={extraClass.join(' ')}
                         handleClick={null}
                         handleMouseEnter={null}
                         type={self.props.thumbnail.type}

--- a/src/js/modules/utils.js
+++ b/src/js/modules/utils.js
@@ -289,7 +289,6 @@ var UTILS = {
             label: '50+'
         }
     ],
-    LOWSCORE_LIMIT: 60,
     TELEMETRY_SNIPPET: 'https://s3.amazonaws.com/neon-cdn-assets/plugins/brightcove-smart-tracker.swf?neonPublisherId=',
     SHARE_LINK_FACEBOOK: 'https://facebook.com/sharer.php',
     SHARE_LINK_TWITTER: 'https://twitter.com/share',

--- a/src/js/xx/components/Collection/Images.js
+++ b/src/js/xx/components/Collection/Images.js
@@ -40,6 +40,7 @@ export default class XXCollectionImages extends React.Component {
                         score={49}
                         size="large"
                         src="/img/xx/temporary/thumbnail-1.jpg"
+                        className="xxThumbnail--lowLight"
                     />
                 </div>
 
@@ -53,6 +54,7 @@ export default class XXCollectionImages extends React.Component {
                         onClick={e => {e.preventDefault(); updateStage('image-zoom');}}
                         onMouseEnter={e => updateStage('image-hover')}
                         onMouseLeave={e => updateStage('')}
+                        className="xxThumbnail--highLight"
                     />
                 </div>
 
@@ -77,30 +79,35 @@ export default class XXCollectionImages extends React.Component {
                         score={75}
                         src="/img/xx/temporary/thumbnail-2.jpg"
                         onClick={e => {e.preventDefault(); updateStage('image-zoom');}}
+                        className="xxThumbnail--highLight"
                     />
                     <XXThumbnail
                         href={isMobile ? null : '#'}
                         score={74}
                         src="/img/xx/temporary/thumbnail-2.jpg"
                         onClick={e => {e.preventDefault(); updateStage('image-zoom');}}
+                        className="xxThumbnail--highLight"
                     />
                     <XXThumbnail
                         href={isMobile ? null : '#'}
                         score={71}
                         src="/img/xx/temporary/thumbnail-2.jpg"
                         onClick={e => {e.preventDefault(); updateStage('image-zoom');}}
+                        className="xxThumbnail--highLight"
                     />
                     <XXThumbnail
                         href={isMobile ? null : '#'}
                         score={69}
                         src="/img/xx/temporary/thumbnail-2.jpg"
                         onClick={e => {e.preventDefault(); updateStage('image-zoom');}}
+                        className="xxThumbnail--highLight"
                     />
                     <XXThumbnail
                         href={isMobile ? null : '#'}
                         score={60}
                         src="/img/xx/temporary/thumbnail-2.jpg"
                         onClick={e => {e.preventDefault(); updateStage('image-zoom');}}
+                        className="xxThumbnail--highLight"
                     />
                     {
                         isMobile ? null : (
@@ -128,36 +135,42 @@ export default class XXCollectionImages extends React.Component {
                                     score={55}
                                     src="/img/xx/temporary/thumbnail-1.jpg"
                                     onClick={e => {e.preventDefault(); updateStage('image-zoom');}}
+                                    className="xxThumbnail--lowLight"
                                 />
                                 <XXThumbnail
                                     href={isMobile ? null : '#'}
                                     score={52}
                                     src="/img/xx/temporary/thumbnail-1.jpg"
                                     onClick={e => {e.preventDefault(); updateStage('image-zoom');}}
+                                    className="xxThumbnail--lowLight"
                                 />
                                 <XXThumbnail
                                     href={isMobile ? null : '#'}
                                     score={49}
                                     src="/img/xx/temporary/thumbnail-1.jpg"
                                     onClick={e => {e.preventDefault(); updateStage('image-zoom');}}
+                                    className="xxThumbnail--lowLight"
                                 />
                                 <XXThumbnail
                                     href={isMobile ? null : '#'}
                                     score={48}
                                     src="/img/xx/temporary/thumbnail-1.jpg"
                                     onClick={e => {e.preventDefault(); updateStage('image-zoom');}}
+                                    className="xxThumbnail--lowLight"
                                 />
                                 <XXThumbnail
                                     href={isMobile ? null : '#'}
                                     score={46}
                                     src="/img/xx/temporary/thumbnail-1.jpg"
                                     onClick={e => {e.preventDefault(); updateStage('image-zoom');}}
+                                    className="xxThumbnail--lowLight"
                                 />
                                 <XXThumbnail
                                     href={isMobile ? null : '#'}
                                     score={43}
                                     src="/img/xx/temporary/thumbnail-1.jpg"
                                     onClick={e => {e.preventDefault(); updateStage('image-zoom');}}
+                                    className="xxThumbnail--lowLight"
                                 />
                             </div>
                         ) : null

--- a/src/js/xx/components/ImageZoom.js
+++ b/src/js/xx/components/ImageZoom.js
@@ -56,6 +56,7 @@ export default class XXPageOverlay extends React.Component {
                                 size="large"
                                 src="/img/xx/temporary/thumbnail-5.jpg"
                                 style={{paddingBottom: `${356 / 636 * 100}%`}}
+                                className="xxThumbnail--highLight"
                             />
                         </div>*/}
                         {/*<div className="xxImageZoom-image xxImageZoom-image--square">
@@ -65,6 +66,7 @@ export default class XXPageOverlay extends React.Component {
                                 size="large"
                                 src="/img/xx/temporary/thumbnail-4.jpg"
                                 style={{paddingBottom: `${636 / 636 * 100}%`}}
+                                className="xxThumbnail--highLight"
                             />
                         </div>*/}
                         {/*
@@ -81,7 +83,7 @@ export default class XXPageOverlay extends React.Component {
                             style={{maxWidth: `calc((100vh - 242px) / (496 / 370))`}}
                         >
                             <XXThumbnail
-                                className="xxThumbnail--zoom"
+                                className="xxThumbnail--zoom xxThumbnail--highLight"
                                 score={75}
                                 size="large"
                                 src="/img/xx/temporary/thumbnail-3.jpg"

--- a/src/js/xx/components/Thumbnail.js
+++ b/src/js/xx/components/Thumbnail.js
@@ -11,9 +11,6 @@ export default ({ href, className, score, size, src, ...tagProps }) => {
     if (size) {
         rootClassName.push(`xxThumbnail--${size}`);
     }
-    if (score < 60) {
-        rootClassName.push('xxThumbnail--lowScore');
-    }
     if (className) {
         rootClassName.push(className);
     }


### PR DESCRIPTION
- removed colour dependent on low score
- thumbnails NeonScore is now either `highLight` or `lowLight` (orange
  or grey)
- default thumbnail and low scores is `lowLight`
- high scores and neon thumbnail is `highLight`
- fix special case for Image Zoom (where default currently appears)
- update xx Sandbox to work with slight new implementation
