### PR TITLE
Drop decimal from estimated time remaining #1396

### DIFF
--- a/src/js/components/pages/DemoUploadPage.js
+++ b/src/js/components/pages/DemoUploadPage.js
@@ -67,7 +67,7 @@ export default React.createClass({
             } else {
                 this.setState({
                     isAnalyzing: true,
-                    seconds: estimatedTimeRemaining,
+                    seconds: parseInt(estimatedTimeRemaining),
                     videoId,
                 });
             }


### PR DESCRIPTION
When given a decimal number for estimatedTimeRemaining. When the number
is a decimal it causes issues with the timer when it is complete. Such
as showing '0-1:0-1'.
