### PR TITLE
Mixed Content warnings #1397

### DIFF
--- a/src/js/components/knave/Thumbnail.js
+++ b/src/js/components/knave/Thumbnail.js
@@ -54,7 +54,7 @@ import UTILS from '../../modules/utils';
             >
                 <img
                     className="xxThumbnail-image"
-                    src={self.props.src}
+                    src={UTILS.stripProtocol(self.props.src)}
                     onMouseEnter={self.handleMouseEnter}
                     alt={self.props.title}
                     title={self.props.title}


### PR DESCRIPTION
- stripping the protocol at the point of render (the `img` tag itself)
