### PR TITLE
Revert "Mixed Content warnings #1397"

### DIFF
--- a/src/js/components/knave/Thumbnail.js
+++ b/src/js/components/knave/Thumbnail.js
@@ -51,7 +51,7 @@ import UTILS from '../../modules/utils';
             >
                 <img
                     className="xxThumbnail-image"
-                    src={UTILS.stripProtocol(self.props.src)}
+                    src={self.props.src}
                     onMouseEnter={self.handleMouseEnter}
                     alt={self.props.title}
                     title={self.props.title}


### PR DESCRIPTION
Reverts neon-lab/wonderland#467
- I added stripProtocol
- To get rid of warnings
- When we on HTTPS and asking for HTTP thumbs
- BUT
- Our neon-images server
- When you ask for the HTTPS version, it replies 401
- Its not setup properly
- So my fix was right
- I didn’t know the thumbs wouldn’t be served
- Cause locally we only HTTP
