### PR TITLE
Old Warped Videos #1408

### DIFF
--- a/src/css/xx/components/_thumbnail.scss
+++ b/src/css/xx/components/_thumbnail.scss
@@ -100,6 +100,8 @@ $thumbnail-hover-border: 2px;
     border-radius: 2px;
     border: $thumbnail-hover-border solid rgba($accent-color, 0);
     transition: border-color $default-transition;
+    // helps with old(er) warped videos - #1408
+    object-fit: cover;
 
     .xxThumbnail[href]:hover > & {
         border-color: $accent-color;

--- a/src/js/modules/renditions.js
+++ b/src/js/modules/renditions.js
@@ -12,7 +12,9 @@ var RENDITIONS = {
     fuzzyEqual: function(a, b, fuzz) {
         return (Math.abs(a - b) <= fuzz);
     },
-    
+    equal: function(w1, h1, w2, h2) {
+        return ((w1 === w2) && (h1 === h2));
+    },
     findRendition: function(thumbnails, width, height) {
         var i = 0;
         if (!thumbnails || thumbnails.length === 0 || width === 0 || height === 0 || thumbnails[0].renditions.length === 0) {
@@ -21,13 +23,13 @@ var RENDITIONS = {
         // We assume each thumbnail is the same so we only need to check the
         // first one
         for (let r of thumbnails[0].renditions) {
-            if ((r.width === width) && (r.height === height)) {
+            if (this.equal(r.width, width, r.height, height)) {
                 return i;
             }
             if (this.fuzzyEqual(r.width, width, this.FUZZ) && this.fuzzyEqual(r.height, height, this.FUZZ)) {
                 return i;    
             }
-            // Aspect Ratio check TODO - future ticket
+            // Aspect Ratio check TODO - future ticket, for now see #1408
             i++;
         }
         return this.NO_RENDITION;


### PR DESCRIPTION
# Changes
- added some comments for my future self
- new function `equal`
- added `object-fit: cover` code to help with the older videos that
  don’t have a square rendition
# Test Plan
- make sure a new video still looks good in Results AND Image Zoom
- make sure old video (pre-square rendition) looks good in Results AND Image Zoom
