### PR TITLE
Images not ordered correctly #1405

### DIFF
--- a/src/css/xx/components/_thumbnail.scss
+++ b/src/css/xx/components/_thumbnail.scss
@@ -47,6 +47,7 @@ $thumbnail-hover-border: 2px;
     }
 
     &--lowLight {
+        cursor: default;
         &::after {
             background-color: $base-color;
         }
@@ -76,7 +77,6 @@ $thumbnail-hover-border: 2px;
         cursor: default;
     }
 
-    &--regular,
     &--neon {
         cursor: pointer;
     }

--- a/src/js/components/knave/ThumbnailCollection.js
+++ b/src/js/components/knave/ThumbnailCollection.js
@@ -41,6 +41,7 @@ var ThumbnailCollection = React.createClass({
                                     src={src}
                                     isMobile={self.props.isMobile}
                                     extraClass='xxThumbnail--lowLight'
+                                    showHref={false}
                                 />
                             )
                         })

--- a/src/js/components/wonderland/Thumbnails.js
+++ b/src/js/components/wonderland/Thumbnails.js
@@ -147,7 +147,7 @@ var Thumbnails = React.createClass({
                     {
                         self.state.showLowScores || self.props.isMobile ? (
                             <ThumbnailCollection
-                                thumbnails={self.state.badThumbs}
+                                thumbnails={UTILS.fixThumbnails(self.state.badThumbs, false)}
                                 type="lowScores"
                                 isMobile={self.props.isMobile}
                             />

--- a/src/js/components/wonderland/VideoGuest.js
+++ b/src/js/components/wonderland/VideoGuest.js
@@ -70,7 +70,7 @@ var VideoGuest = React.createClass({
                         duration: video.duration,
                         url: video.url,
                         thumbnails: newThumbnails.thumbnails,
-                        sortedThumbnails: UTILS.fixThumbnails(newThumbnails.thumbnails),
+                        sortedThumbnails: UTILS.fixThumbnails(newThumbnails.thumbnails, true),
                         videoState: video.state,
                         videoStateMapping: UTILS.VIDEO_STATE[video.state].mapping,
                         created: video.created,

--- a/src/js/components/wonderland/VideoOwner.js
+++ b/src/js/components/wonderland/VideoOwner.js
@@ -36,7 +36,7 @@ var VideoOwner = React.createClass({
             videoState: self.props.videoState,
             videoStateMapping: UTILS.VIDEO_STATE[self.props.videoState].mapping,
             thumbnails: self.props.thumbnails,
-            sortedThumbnails: UTILS.fixThumbnails(self.props.thumbnails),
+            sortedThumbnails: UTILS.fixThumbnails(self.props.thumbnails, true),
             title: self.props.title,
             created: self.props.created,
             error: self.props.error,
@@ -140,7 +140,7 @@ var VideoOwner = React.createClass({
                         self.setState({
                             status: 200,
                             thumbnails: newThumbnails.thumbnails,
-                            sortedThumbnails: UTILS.fixThumbnails(newThumbnails.thumbnails),
+                            sortedThumbnails: UTILS.fixThumbnails(newThumbnails.thumbnails, true),
                             videoState: video.state,
                             videoStateMapping: UTILS.VIDEO_STATE[video.state].mapping,
                             title: video.title,

--- a/src/js/modules/utils.js
+++ b/src/js/modules/utils.js
@@ -315,17 +315,34 @@ var UTILS = {
     rando: function(num) {
         return Math.floor(Math.random() * num + 1);
     },
-    fixThumbnails: function(rawThumbnails) {
+    _sortThumbnails: function(a, b) {
+        var aScore = (a.neon_score ? a.neon_score : 0),
+            bScore = (b.neon_score ? b.neon_score : 0)
+        ;
+        return bScore - aScore;
+    },
+    fixThumbnails: function(rawThumbnails, ignoreBad) {
+
+        if (!(Array.isArray(rawThumbnails) && rawThumbnails.length > 0)) {
+            return [];
+        }
+
         var defaults = [],
             customs = [],
             neons = [],
             nonNeons = []
         ;
+
         // Pass 1 - sort into `default`, `custom` and `neon`
         rawThumbnails.map(function(rawThumbnail, i) {
             switch (rawThumbnail.type) {
                 case 'neon':
                     neons.push(rawThumbnail);
+                    break;                    
+                case 'bad_neon':
+                    if (!ignoreBad) {
+                        neons.push(rawThumbnail);
+                    }
                     break;
                 case 'custom':
                     customs.push(rawThumbnail);
@@ -338,14 +355,13 @@ var UTILS = {
                     break;
             }
         });
-        // Pass 2 - sort `custom` by rank ASC
-        customs.sort(function(a, b) {
-            return a.rank - b.rank;
-        });
-        // Pass 3 - sort `neon` by rank ASC
-        neons.sort(function(a, b) {
-            return (a.rank === '?' ? 0 : a.rank) - (b.rank === '?' ? 0 : b.rank);
-        });
+
+        // Pass 2 - sort `custom` by neon_score DESC
+        customs.sort(this._sortThumbnails);
+
+        // Pass 3 - sort `neon` by neon_score DESC
+        neons.sort(this._sortThumbnails);
+
         // Pass 4 - assemble the output
         nonNeons = customs.concat(defaults);
         if (nonNeons.length > 0) {


### PR DESCRIPTION
- add new helper function `sortThumbnails` (uses `neon_score` rather
  than `rank`)
- both customs and neons now use this sort method
- also sort `badThumbs` so type `bad_neon` also added to the
  `fixThumbnails` function
- fixed cursors for `lowLight` thumbs
- don’t render anchor for low scores
