### PR TITLE
View Low Scores widget shows when no low score thumbnails: #1411 #1412

### DIFF
--- a/src/js/components/wonderland/Thumbnails.js
+++ b/src/js/components/wonderland/Thumbnails.js
@@ -130,8 +130,11 @@ var Thumbnails = React.createClass({
                     />
                     {
                         self.props.isMobile || self.state.badThumbs.length < 1 ? null : (
-                            <strong className="xxCollectionImages-allAnchor">
-                                <span onClick={self.toggleLowScoresVisibility}>
+                            <strong 
+                                className="xxCollectionImages-allAnchor"
+                                onClick={self.toggleLowScoresVisibility}
+                            >
+                                <span>
                                     {self.state.showLowScores ? T.get('copy.thumbnails.high') : T.get('copy.thumbnails.low')}
                                 </span>
                             </strong>


### PR DESCRIPTION
add logic to hide thumbnails if none are present in the badthumbs array
move onClick to strong element parent  
JIRA: https://neonlabs.atlassian.net/browse/NEON-1411
