### PR TITLE
Root PageShown If Logged In #1355

### DIFF
--- a/src/js/components/pages/HomePage.js
+++ b/src/js/components/pages/HomePage.js
@@ -1,4 +1,4 @@
-import React, {Component, PropTypes} from 'react';
+import React, {PropTypes} from 'react';
 import { Link } from 'react-router';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import Helmet from 'react-helmet';


### PR DESCRIPTION
# Changes
- updated `HomePage` to redirect user to `VideosPage` if they are signed in
# Test Plan
- sign in to a normal account
- try clicking the "Neon" logo, and check that you are redirected to the video results page
- sign out
- check that you can go to the homepage
