### PR TITLE
Remove NeonScore for Video (Beta 1.0) from landing page #1429

### DIFF
--- a/src/js/components/pages/HomePage.js
+++ b/src/js/components/pages/HomePage.js
@@ -54,7 +54,6 @@ export default class HomePage extends React.Component {
                 <ReactCSSTransitionGroup transitionName="xxFadeInOut" transitionEnterTimeout={400} transitionLeaveTimeout={400}>
                     <div>
                         <article className="xxFeatureContent" key="home-featureContent">
-                            <h2 className="xxSubtitle">{T.get('copy.homePage.neonBeta')}</h2>
                             <h1 className="xxTitle xxFeatureContent-title">{T.get('copy.homePage.title')}</h1>
                             <p>{T.get('copy.homePage.description')}</p>
                             <div className="xxFormButtons xxFeatureContent-buttons">

--- a/src/js/modules/translation.js
+++ b/src/js/modules/translation.js
@@ -361,7 +361,6 @@ const _DEFAULT_LOCALE = 'en-US',
             // Home page
             'copy.homePage.title': 'Find your most clickable images',
             'copy.homePage.description': 'Upload a video and Neon will show you the thumbnails that will give you the most clicks.',
-            'copy.homePage.neonBeta': 'NeonScore for Video (beta 1.0)',
             'copy.homePage.signedUp': 'Already Signed Up?',
 
             // Onboarding


### PR DESCRIPTION
- removed translation and use of translation (as per ticket)
