### PR TITLE
Into Image Zoom then out returns you to the top of the results (not where you were) #1455

### DIFF
--- a/src/js/components/knave/Thumbnail.js
+++ b/src/js/components/knave/Thumbnail.js
@@ -62,7 +62,7 @@ import UTILS from '../../modules/utils';
     handleThumbnailClick: function(e) {
         var self = this;
         if (self.props.handleClick) {
-            self.props.handleClick(self.props.uid);
+            self.props.handleClick(e, self.props.uid);
         }
     },
     handleMouseEnter: function() {

--- a/src/js/components/wonderland/Thumbnails.js
+++ b/src/js/components/wonderland/Thumbnails.js
@@ -64,11 +64,11 @@ var Thumbnails = React.createClass({
         });
     },
     closeThumbnailOverlay: function(e) {
-        e.preventDefault();
         var self = this;
-        self.toggleThumbnailOverlay(self.state.selectedItem);
+        self.toggleThumbnailOverlay(e, self.state.selectedItem);
     },
-    toggleThumbnailOverlay: function(selectedItem) {
+    toggleThumbnailOverlay: function(e, selectedItem) {
+        e.preventDefault();
         var self = this;
         self.setState({
             isThumbnailOverlayActive: !self.state.isThumbnailOverlayActive,


### PR DESCRIPTION
- make sure the event makes it to the `toggleThumbnailOverlay` function
  so we can call `e.preventDefault`
- bad branch name
- https://neonlabs.atlassian.net/browse/NEON-1455
