### PR TITLE
User Reset Token URL no worky #1409

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -153,12 +153,24 @@ gulp.task('browser-sync', function() {
         },
         middleware: [historyApiFallback({
             // https://github.com/bripkens/connect-history-api-fallback#rewrites
-            rewrites: [{
-                from: /\/video\/.*/, to: '/index.html',
-                from: /\/account\/confirm\/.*/, to: '/index.html',
-                from: /\/user\/reset\/token\/.*/, to: '/index.html',
-                from: /\/share\/.*/, to: '/index.html'
-            }]
+            rewrites: [
+                {
+                    from: /\/video\/.*/,
+                    to: '/index.html'
+                },
+                {
+                    from: /\/account\/confirm\/.*/,
+                    to: '/index.html'
+                },
+                {
+                    from: /\/user\/reset\/token\/.*/,
+                    to: '/index.html'
+                },
+                {
+                    from: /\/share\/.*/,
+                    to: '/index.html'
+                }
+            ]
         })],
         ghostMode: false
     });


### PR DESCRIPTION
- fixed error where `rewrites` array contained one object stuffed (and
  magically worked), whereas it should be an array of objects
- great bug and great bug fix by myself
