### PR TITLE
Tweets will only be sent to @neonlab (treated as a reply or pseudo-direct-reply) #1539

### DIFF
--- a/src/js/modules/translation.js
+++ b/src/js/modules/translation.js
@@ -303,7 +303,7 @@ const _DEFAULT_LOCALE = 'en-US',
             // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
             'copy.share.facebook': '@neonthumbnails found the best image in my video and gave it a NeonScore. What’s your NeonScore?',
-            'copy.share.twitter': '@neonlab found the best image in my video and gave it a NeonScore. What’s your #NeonScore?',
+            'copy.share.twitter': '.@neonlab found the best image in my video and gave it a NeonScore. What’s your #NeonScore?',
             'copy.share.linkedin': 'Neon found the best image in my video and gave it a NeonScore. What’s your NeonScore?',
             'copy.share.contentTitle': 'What\'s your Neon Score?',
             'copy.share.description': 'Copy the link below to share this collection. Anyone with this link can view your images for this video.',


### PR DESCRIPTION
- added a full stop `.` before the `@` to prevent it being a reply
