### PR TITLE
Add reload and tag_type search for Oracle

### DIFF
--- a/src/js/components/pages/CollectionsMainPage.js
+++ b/src/js/components/pages/CollectionsMainPage.js
@@ -99,7 +99,6 @@ const CollectionsMainPage = React.createClass({
         // Load initial results: first 2 quickly and a whole page or more.
         const callback = Search.load.bind(null, UTILS.RESULTS_PAGE_SIZE);
         Search.load(2, true, callback);
-        setInterval(Search.reload.bind(null, 5), 5000);
     },
 
     updateState: function() {

--- a/src/js/stores/CollectionStores.js
+++ b/src/js/stores/CollectionStores.js
@@ -862,7 +862,7 @@ export const LoadActions = Object.assign({}, AjaxMixin, {
     //         if false, don't call the backend if the number of
     //             tags in the FilteredTagStore exceeds n
     //         if true, always call the backend
-    loadNNewestTags(n, query, type, force, callback) {
+    loadNNewestTags(n, query=null, type=null, force=false, callback=null) {
         const self = this;
         const haveCount = FilteredTagStore.count();
 
@@ -1069,7 +1069,7 @@ export const Search = {
         return count + UTILS.RESULTS_PAGE_SIZE + 1;
     },
 
-    load(count, onlyThisMany=false, callback) {
+    load(count, onlyThisMany=false, callback=null) {
         // Aggressively load tags unless caller specifies only this many.
         const largeCount = onlyThisMany? count: Search.getLargeCount(count);
         Search.incrementPending();
@@ -1077,14 +1077,14 @@ export const Search = {
         LoadActions.loadNNewestTags(largeCount, null, null, false, wrapped);
     },
 
-    loadWithQuery(count, query, type, callback) {
+    loadWithQuery(count, query=null, type=null, callback=null) {
         const largeCount = Search.getLargeCount(count);
         Search.incrementPending();
         const wrapped = Search.getWrappedCallback(callback);
         LoadActions.loadNNewestTags(largeCount, query, type, false, wrapped);
     },
 
-    reload(count, query, type, callback) {
+    reload(count, query=null, type=null, callback=null) {
         Search.incrementPending();
         const wrapped = Search.getWrappedCallback(callback);
         LoadActions.loadNNewestTags(count, query, type, true, wrapped);


### PR DESCRIPTION
I didn't demo it but there's also a tag_type type argument for reload. You'll still need to write the filter for FilteredTagStore if you end up using it, but this will handle getting the results from the backend
