### PR TITLE
Tweaking Timeline config to have 2 Oracle feeds & Added Threshold functionality

### DIFF
--- a/env/timeline/timeline.config.json
+++ b/env/timeline/timeline.config.json
@@ -1,14 +1,23 @@
 {
-    oracle2016: {
+    oracle2016a: {
         'UN': 'read_only_oracle',
         'PW': '8YW9sKxcjxPj3GKa',
         'FEED': 'http://oracleuniversal2-lh.akamaihd.net/i/oracle_hd2@134506/master.m3u8',
-        'TITLE': 'Oracle 2016'
+        'TITLE': 'Oracle 2016 A',
+        'THRESHOLD': 0
+    },
+    oracle2016b: {
+        'UN': 'read_only_oracle',
+        'PW': '8YW9sKxcjxPj3GKa',
+        'FEED': 'http://oracleuniversal-lh.akamaihd.net/i/oracle_hd@146167/master.m3u8',
+        'TITLE': 'Oracle 2016 B',
+        'THRESHOLD': 0
     },
     ign: {
         'UN': 'ign_user',
         'PW': 'u4bwZTUr9RWz',
         'FEED': '',
-        'TITLE': 'IGN'
+        'TITLE': 'IGN',
+        'THRESHOLD': 50
     }
 }

--- a/src/js/components/knave/Timeline.js
+++ b/src/js/components/knave/Timeline.js
@@ -13,12 +13,14 @@ import _ from 'lodash';
 const Timeline = React.createClass({
     propTypes: {
         stores: React.PropTypes.object.isRequired,
-        feed: React.PropTypes.string
+        feed: React.PropTypes.string,
+        threshold: React.PropTypes.number
     },
     getDefaultProps: function() {
         return {
             stores: {},
-            feed: ''
+            feed: '',
+            threshold: 0
         }
     },
     getInitialState: function() {
@@ -53,7 +55,7 @@ const Timeline = React.createClass({
 
                         // We are only interested in good thumbnails (neon ones)    
                         const neonThumbnails = demographicThumbnailObject.thumbnails.filter(function(t) {
-                            return t.type === 'neon'
+                            return (t.type === 'neon' && t.neon_score >= self.props.threshold)
                         });
                     
                         // We need to iterate each one and get the best rendition
@@ -63,7 +65,8 @@ const Timeline = React.createClass({
                                 thumbnailId: t.thumbnail_id,
                                 timestamp: new Date(t.updated).getTime(),
                                 lowSrc: RENDITIONS.findRendition(t, 160 * 3, 90 * 3),
-                                highSrc: t.url
+                                highSrc: t.url,
+                                neonScore: t.neon_score
                             });
                         });
 
@@ -81,7 +84,7 @@ const Timeline = React.createClass({
         ;
         return (
             <div>
-                <ol className="timeline">
+                <ol className="timeline" data-threshold={self.props.threshold} data-feed={self.props.feed}>
                     {
                         snapshots.map(function(snapshot, i) {
                             return (
@@ -95,6 +98,7 @@ const Timeline = React.createClass({
                                             data-video-id={snapshot.videoId}
                                             data-thumbnail-id={snapshot.videoId}
                                             data-timestamp={snapshot.timestamp}
+                                            data-neonscore={snapshot.neonScore}
                                             src={snapshot.lowSrc}
                                             alt=''
                                             title=''

--- a/src/js/components/pages/TimelinePage.js
+++ b/src/js/components/pages/TimelinePage.js
@@ -76,7 +76,8 @@ var timelinePage = React.createClass({
                 title: T.get('copy.timelinePage.title', {
                     '@title': timelineConfig.TITLE
                 }),
-                feed: timelineConfig.FEED
+                feed: timelineConfig.FEED,
+                threshold: timelineConfig.THRESHOLD
             }, function() {
                 self.POST('authenticate', {
                     host: CONFIG.AUTH_HOST,
@@ -119,6 +120,7 @@ var timelinePage = React.createClass({
                         videos: self.state.videos,
                     }}
                     feed={self.state.feed}
+                    threshold={self.state.threshold}
                 />
                 <SiteFooter />
             </main>


### PR DESCRIPTION
- added 2 Oracle Feeds
- added JSON timeline entry for `THRESHOLD` (we use this to only show images with this NeonScore and above)
- this means we now have a `threshold` prop in our `Timeline` component
- outputting some of the `config` and `neon_score` values as data attributes
