### PR TITLE
Score color is different in collection view and in image zoom view #1782

### DIFF
--- a/src/js/components/knave/ThumbnailOverlay.js
+++ b/src/js/components/knave/ThumbnailOverlay.js
@@ -61,7 +61,13 @@ var ThumbnailOverlay = React.createClass({
         if (index === 0) {
             return 'xxThumbnail--lowLight';
         }
-        if (thumbnail.type === 'neon') {
+        // We need to handle the case where one of the top thumbnails is the
+        // random or centerframe
+        if (
+            thumbnail.type === 'neon' ||
+            thumbnail.type === 'random' ||
+            thumbnail.type === 'centerframe'
+        ) {
             return 'xxThumbnail--highLight';
         }
         if (this.props.tagType === UTILS.TAG_TYPE_IMAGE_COL &&


### PR DESCRIPTION
- if the `random` or `centerframe` also make it into the top 6 then we
  need to colour them appropriately
