### PR TITLE
Filter image collection tags if they have no thumbnail

### DIFF
--- a/src/js/components/pages/CollectionsMainPage.js
+++ b/src/js/components/pages/CollectionsMainPage.js
@@ -350,9 +350,12 @@ const CollectionsMainPage = React.createClass({
         } else {
             // Apply a non-empty search to our data provider.
             filteredTagStore.setFilter(
-                tag => {
-                    return tag.hidden !== true && self.filterOnName(searchQuery, tag)
-                }
+                tag => (
+                    // TODO factor this and the default filter.
+                    tag.hidden !== true &&
+                        (tag.thumbnail_ids.length > 0  || tag.tag_type !== UTILS.TAG_TYPE_IMAGE_COL) &&
+                        self.filterOnName(searchQuery, tag)
+                )
             );
         }
 

--- a/src/js/stores/CollectionStores.js
+++ b/src/js/stores/CollectionStores.js
@@ -187,7 +187,8 @@ class FilteredStore {
     }
 
     defaultFilter(item) {
-        return item.hidden !== true;
+        return (item.thumbnail_ids.length > 0 || item.tag_type !== UTILS.TAG_TYPE_IMAGE_COL) &&
+            item.hidden !== true;
     }
 
     setFilter(filter) {


### PR DESCRIPTION
This guards against tags that are empty, which the add-image flow now can create.
